### PR TITLE
Nisse/v0.5.5/cpu count for containers

### DIFF
--- a/paralleldomain/encoding/encoder.py
+++ b/paralleldomain/encoding/encoder.py
@@ -17,10 +17,11 @@ from paralleldomain.model.type_aliases import SceneName, SensorName
 from paralleldomain.model.unordered_scene import UnorderedScene
 from paralleldomain.utilities.any_path import AnyPath
 from paralleldomain.utilities.fsio import relative_path
+from paralleldomain.utilities.os import cpu_count
 
 logger = logging.getLogger(__name__)
 
-_thread_pool_size = max(int(os.environ.get("ENCODER_THREAD_POOL_MAX_SIZE", os.cpu_count() * 4)), 4)
+_thread_pool_size = max(int(os.environ.get("ENCODER_THREAD_POOL_MAX_SIZE", cpu_count() * 4)), 4)
 
 
 class EncoderThreadPool(ThreadPoolExecutor):

--- a/paralleldomain/utilities/any_path.py
+++ b/paralleldomain/utilities/any_path.py
@@ -9,6 +9,8 @@ from urllib.parse import urlparse
 from awscli.clidriver import create_clidriver
 from s3path import S3Path
 
+from paralleldomain.utilities.os import cpu_count
+
 logger = logging.getLogger(__name__)
 
 
@@ -65,7 +67,7 @@ class AnyPath:
     def copytree(self, target: "AnyPath", max_num_threads: Optional[int] = None):
         target = AnyPath(str(target))
         if max_num_threads is None:
-            max_num_threads = max(1, min(int(0.5 * (os.cpu_count() or 1)), 10))
+            max_num_threads = max(1, min(int(0.5 * (cpu_count() or 1)), 10))
 
         def _copy(source: Path):
             if source.is_file():

--- a/paralleldomain/utilities/lazy_load_cache.py
+++ b/paralleldomain/utilities/lazy_load_cache.py
@@ -10,8 +10,6 @@ import numpy as np
 from cachetools import Cache
 from humanize import naturalsize
 
-from paralleldomain.utilities.os import virtual_memory
-
 CachedItemType = TypeVar("CachedItemType")
 
 logger = logging.getLogger(__name__)
@@ -227,11 +225,8 @@ def byte_str_to_bytes(byte_str: str) -> int:
     return int(total_bits)
 
 
-cache_max_size = os.environ.get("CACHE_MAX_BYTES")
-if cache_max_size is None:
-    total_ram_size = virtual_memory().total
-    cache_max_size = naturalsize(max(1_000_000_000, int(total_ram_size * 0.9)), binary=False)
-
+cache_max_ram_usage_factor = float(os.environ.get("CACHE_MAX_USAGE_FACTOR", 0.1))  # 10% free space max
+cache_max_size = os.environ.get("CACHE_MAX_BYTES", "1GiB")
 if "CACHE_MAX_USAGE_FACTOR" in os.environ:
     logger.warning(
         "CACHE_MAX_USAGE_FACTOR is not longer supported! Use CACHE_MAX_BYTES instead to set a cache size in bytes!"

--- a/paralleldomain/utilities/os.py
+++ b/paralleldomain/utilities/os.py
@@ -1,25 +1,58 @@
 import os
+import sys
+from dataclasses import dataclass
+
+import psutil
+from cgroupspy.trees import Tree
+
+from paralleldomain.utilities.any_path import AnyPath
 
 
 def is_container() -> bool:
-    path = "/proc/self/cgroup"
-    return os.path.exists("/.dockerenv") or os.path.isfile(path) and any("docker" in line for line in open(path))
+    """Returns `True` if process is running inside a (Docker) container."""
+    cgroup_path = AnyPath("/proc/self/cgroup")
+    return (
+        AnyPath("/.dockerenv").exists()
+        or cgroup_path.is_file()
+        and any("docker" in line for line in cgroup_path.open(mode="r"))
+    )
 
 
 def cpu_count() -> int:
+    """Returns CPU count. If process is running inside a (Docker) container,
+    it returns the allocated virtual CPU count."""
     if is_container():
-        if os.path.isfile("/sys/fs/cgroup/cpu/cpu.cfs_quota_us"):
-            cpu_quota = int(open("/sys/fs/cgroup/cpu/cpu.cfs_quota_us").read().rstrip())
-        # print(cpu_quota) # Not useful for AWS Batch based jobs as result is -1, but works on local linux systems
-        if cpu_quota != -1 and os.path.isfile("/sys/fs/cgroup/cpu/cpu.cfs_period_us"):
-            cpu_period = int(open("/sys/fs/cgroup/cpu/cpu.cfs_period_us").read().rstrip())
-            # print(cpu_period)
-            avail_cpu = int(cpu_quota / cpu_period)
-            # Divide quota by period and you should get num of allotted CPU to the container,rounded down if fractional.
-        elif os.path.isfile("/sys/fs/cgroup/cpu/cpu.shares"):
-            cpu_shares = int(open("/sys/fs/cgroup/cpu/cpu.shares").read().rstrip())
-            # print(cpu_shares) # For AWS, gives correct value * 1024.
-            avail_cpu = int(cpu_shares / 1024)
-        return avail_cpu
+        cgroup_tree = Tree()
+        cpu_controller = cgroup_tree.get_node_by_path("/cpu/").controller
+        if cpu_controller.cfs_quota_us is None:  # running inside AWS-hosted container
+            return int(cpu_controller.shares / 1024)
+        else:  # running locally hosted container
+            return int(cpu_controller.cfs_quota_us / cpu_controller.cfs_period_us)
     else:
         return os.cpu_count()
+
+
+@dataclass
+class Memory:
+    total: int
+    used: int
+
+    @property
+    def available(self) -> int:
+        return self.total - self.used
+
+
+def virtual_memory() -> Memory:
+    """Returns total, used and available memory. If process is running inside a (Docker) container,
+    it returns the allocated memory limit, or pyhsical host memory if no explicit limit has been set."""
+    if is_container():
+        cgroup_tree = Tree()
+        memory_controller = cgroup_tree.get_node_by_path("/memory/").controller
+
+        memory_limit = memory_controller.limit_in_bytes
+        if memory_limit == (sys.maxsize - sys.maxsize % 4096):  # no container limit - take host physical limit
+            memory_limit = psutil.virtual_memory().total
+        return Memory(total=memory_limit, used=memory_controller.usage_in_bytes)
+    else:
+        psutil_vm = psutil.virtual_memory()
+        return Memory(total=psutil_vm.total, used=psutil_vm.used)

--- a/paralleldomain/utilities/os.py
+++ b/paralleldomain/utilities/os.py
@@ -1,9 +1,6 @@
 import os
-import sys
-from dataclasses import dataclass
 from pathlib import Path
 
-import psutil
 from cgroupspy.trees import Tree
 
 
@@ -29,29 +26,3 @@ def cpu_count() -> int:
             return int(cpu_controller.cfs_quota_us / cpu_controller.cfs_period_us)
     else:
         return os.cpu_count()
-
-
-@dataclass
-class Memory:
-    total: int
-    used: int
-
-    @property
-    def available(self) -> int:
-        return self.total - self.used
-
-
-def virtual_memory() -> Memory:
-    """Returns total, used and available memory. If process is running inside a (Docker) container,
-    it returns the allocated memory limit, or pyhsical host memory if no explicit limit has been set."""
-    if is_container():
-        cgroup_tree = Tree()
-        memory_controller = cgroup_tree.get_node_by_path("/memory/").controller
-
-        memory_limit = memory_controller.limit_in_bytes
-        if memory_limit == (sys.maxsize - sys.maxsize % 4096):  # no container limit - take host physical limit
-            memory_limit = psutil.virtual_memory().total
-        return Memory(total=memory_limit, used=memory_controller.usage_in_bytes)
-    else:
-        psutil_vm = psutil.virtual_memory()
-        return Memory(total=psutil_vm.total, used=psutil_vm.used)

--- a/paralleldomain/utilities/os.py
+++ b/paralleldomain/utilities/os.py
@@ -1,18 +1,17 @@
 import os
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 import psutil
 from cgroupspy.trees import Tree
 
-from paralleldomain.utilities.any_path import AnyPath
-
 
 def is_container() -> bool:
     """Returns `True` if process is running inside a (Docker) container."""
-    cgroup_path = AnyPath("/proc/self/cgroup")
+    cgroup_path = Path("/proc/self/cgroup")
     return (
-        AnyPath("/.dockerenv").exists()
+        Path("/.dockerenv").exists()
         or cgroup_path.is_file()
         and any("docker" in line for line in cgroup_path.open(mode="r"))
     )

--- a/paralleldomain/utilities/os.py
+++ b/paralleldomain/utilities/os.py
@@ -1,0 +1,25 @@
+import os
+
+
+def is_container() -> bool:
+    path = "/proc/self/cgroup"
+    return os.path.exists("/.dockerenv") or os.path.isfile(path) and any("docker" in line for line in open(path))
+
+
+def cpu_count() -> int:
+    if is_container():
+        if os.path.isfile("/sys/fs/cgroup/cpu/cpu.cfs_quota_us"):
+            cpu_quota = int(open("/sys/fs/cgroup/cpu/cpu.cfs_quota_us").read().rstrip())
+        # print(cpu_quota) # Not useful for AWS Batch based jobs as result is -1, but works on local linux systems
+        if cpu_quota != -1 and os.path.isfile("/sys/fs/cgroup/cpu/cpu.cfs_period_us"):
+            cpu_period = int(open("/sys/fs/cgroup/cpu/cpu.cfs_period_us").read().rstrip())
+            # print(cpu_period)
+            avail_cpu = int(cpu_quota / cpu_period)
+            # Divide quota by period and you should get num of allotted CPU to the container,rounded down if fractional.
+        elif os.path.isfile("/sys/fs/cgroup/cpu/cpu.shares"):
+            cpu_shares = int(open("/sys/fs/cgroup/cpu/cpu.shares").read().rstrip())
+            # print(cpu_shares) # For AWS, gives correct value * 1024.
+            avail_cpu = int(cpu_shares / 1024)
+        return avail_cpu
+    else:
+        return os.cpu_count()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 awscli>=1.20.58,<2.0.0
 coloredlogs>=15.0.1,<16.0.0
 cachetools>=4.2.2,<5.0.0
+cgroupspy>=0.2.1,<1.0.0
 dataclasses>=0.8,<1.0.0; python_version == "3.6"
 dataclasses_json>=0.5.3,<1.0.0
 humanize>=3.10.0,<4.0.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="paralleldomain",
-    version="0.5.3",
+    version="0.5.5",
     author=", ".join(["Nisse Knudsen", "Phillip Thomas", "Lars Pandikow", "Michael Stanley"]),
     author_email=", ".join(
         [

--- a/test_paralleldomain/utilities/test_lazy_load_cache.py
+++ b/test_paralleldomain/utilities/test_lazy_load_cache.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 
-from paralleldomain.utilities.lazy_load_cache import CacheEmptyException, LazyLoadCache
+from paralleldomain.utilities.lazy_load_cache import CacheEmptyException, LazyLoadCache, byte_str_to_bytes
 
 
 class _MockSizeElement:
@@ -145,3 +145,20 @@ class TestLazyLoadCache:
 
         p1 = ThreadPool(140)
         p1.map_async(delete, range(140)).get()
+
+    def test_byte_str_to_bytes(self):
+        test_values = [
+            ("1.048576 MB", "1 MiB", 1_048_576),
+            ("2.45366784 MB", "2.34 MiB", 2_453_667),
+            ("1 TB", "0.90949470177293 TiB", 1_000_000_000_000),
+            ("1 KB", "8 kbit", 1_000),
+        ]
+
+        for ga_bytes, bi_bytes, byte_value in test_values:
+            ga_bytes_no_whitespace = ga_bytes.replace(" ", "")
+            bi_bytes_no_whitespace = ga_bytes.replace(" ", "")
+
+            assert byte_str_to_bytes(byte_str=ga_bytes) == byte_value
+            assert byte_str_to_bytes(byte_str=ga_bytes_no_whitespace) == byte_value
+            assert byte_str_to_bytes(byte_str=bi_bytes) == byte_value
+            assert byte_str_to_bytes(byte_str=bi_bytes_no_whitespace) == byte_value

--- a/test_paralleldomain/utilities/test_os.py
+++ b/test_paralleldomain/utilities/test_os.py
@@ -1,0 +1,14 @@
+from paralleldomain.utilities.os import cpu_count, is_container, virtual_memory
+
+
+def test_is_container():
+    _ = is_container()
+
+
+def test_cpu_count():
+    _ = cpu_count()
+
+
+def test_virtual_memory():
+    v_memory = virtual_memory()
+    assert v_memory.total >= v_memory.used

--- a/test_paralleldomain/utilities/test_os.py
+++ b/test_paralleldomain/utilities/test_os.py
@@ -1,14 +1,11 @@
-from paralleldomain.utilities.os import cpu_count, is_container, virtual_memory
+from paralleldomain.utilities.os import cpu_count, is_container
 
 
 def test_is_container():
-    _ = is_container()
+    # Test execution to assure no error is thrown on non-unix (non-cgroup) OS
+    is_container()
 
 
 def test_cpu_count():
-    _ = cpu_count()
-
-
-def test_virtual_memory():
-    v_memory = virtual_memory()
-    assert v_memory.total >= v_memory.used
+    # Test execution to assure no error is thrown on non-unix (non-cgroup) OS
+    cpu_count()


### PR DESCRIPTION
* Dedicated `cpu_count` and `virtual_memory` methods that abstracts away if PD SDK runs on local host, local docker or AWS docker
* Adapted usage in `EncoderThreadPool`
* Adapted usage in `LazyLoadCache` with dynamic setting if no env variable provided