### PR TITLE
Radar and Lidar DPG/V1 annotations fix

### DIFF
--- a/paralleldomain/decoding/dgp/v1/sensor_frame_decoder.py
+++ b/paralleldomain/decoding/dgp/v1/sensor_frame_decoder.py
@@ -601,6 +601,21 @@ class DGPLidarSensorFrameDecoder(DGPSensorFrameDecoder, LidarSensorFrameDecoder[
         self._decode_point_cloud_format = lru_cache(maxsize=1)(self._decode_point_cloud_format)
         self._decode_point_cloud_data = lru_cache(maxsize=1)(self._decode_point_cloud_data)
 
+    def _decode_available_annotation_types(
+        self, sensor_name: SensorName, frame_id: FrameId
+    ) -> Dict[AnnotationType, AnnotationIdentifier]:
+        datum = self._get_sensor_frame_data_datum(frame_id=frame_id, sensor_name=sensor_name)
+        type_to_path = datum.point_cloud.annotations
+        available_annotation_types = {ANNOTATION_TYPE_MAP[k]: v for k, v in type_to_path.items()}
+
+        point_cache_folder = self._dataset_path / self.scene_name / "point_cache"
+        if BoundingBoxes3D in available_annotation_types and point_cache_folder.exists():
+            available_annotation_types[PointCaches] = "$".join(
+                [available_annotation_types[BoundingBoxes3D], sensor_name, frame_id]
+            )
+
+        return available_annotation_types
+
     def _decode_point_cloud_format(self, sensor_name: SensorName, frame_id: FrameId) -> List[str]:
         datum = self._get_sensor_frame_data_datum(frame_id=frame_id, sensor_name=sensor_name)
         return [point_cloud_pb2.PointCloud.ChannelType.Name(pf) for pf in datum.point_cloud.point_format]
@@ -712,10 +727,7 @@ class DGPRadarSensorFrameDecoder(DGPSensorFrameDecoder, RadarSensorFrameDecoder[
         self, sensor_name: SensorName, frame_id: FrameId
     ) -> Dict[AnnotationType, AnnotationIdentifier]:
         datum = self._get_sensor_frame_data_datum(frame_id=frame_id, sensor_name=sensor_name)
-        if datum.radar_point_cloud:
-            type_to_path = datum.radar_point_cloud.annotations
-        else:
-            raise ValueError("RADAR data not found.")
+        type_to_path = datum.radar_point_cloud.annotations
 
         available_annotation_types = {ANNOTATION_TYPE_MAP[k]: v for k, v in type_to_path.items()}
         return available_annotation_types

--- a/paralleldomain/decoding/dgp/v1/sensor_frame_decoder.py
+++ b/paralleldomain/decoding/dgp/v1/sensor_frame_decoder.py
@@ -282,29 +282,6 @@ class DGPSensorFrameDecoder(SensorFrameDecoder[datetime], metaclass=abc.ABCMeta)
         else:
             raise NotImplementedError(f"{annotation_type} is not implemented yet in this decoder!")
 
-    def _decode_available_annotation_types(
-        self, sensor_name: SensorName, frame_id: FrameId
-    ) -> Dict[AnnotationType, AnnotationIdentifier]:
-        datum = self._get_sensor_frame_data_datum(frame_id=frame_id, sensor_name=sensor_name)
-        if datum.image:
-            type_to_path = datum.image.annotations
-        elif datum.point_cloud:
-            type_to_path = datum.point_cloud.annotations
-        elif datum.radar_point_cloud:
-            type_to_path = datum.radar_point_cloud.annotations
-        else:
-            raise ValueError("None of Camera, LiDAR or RADAR data were found. Other types are currently not supported")
-
-        available_annotation_types = {ANNOTATION_TYPE_MAP[k]: v for k, v in type_to_path.items()}
-
-        point_cache_folder = self._dataset_path / self.scene_name / "point_cache"
-        if BoundingBoxes3D in available_annotation_types and point_cache_folder.exists():
-            available_annotation_types[PointCaches] = "$".join(
-                [available_annotation_types[BoundingBoxes3D], sensor_name, frame_id]
-            )
-
-        return available_annotation_types
-
     # ---------------------------------
 
     def _decode_calibration(self, scene_name: str, calibration_key: str) -> sample_pb2.SampleCalibration:
@@ -540,6 +517,21 @@ class DGPSensorFrameDecoder(SensorFrameDecoder[datetime], metaclass=abc.ABCMeta)
 
 
 class DGPCameraSensorFrameDecoder(DGPSensorFrameDecoder, CameraSensorFrameDecoder[datetime]):
+
+    def _decode_available_annotation_types(
+        self, sensor_name: SensorName, frame_id: FrameId
+    ) -> Dict[AnnotationType, AnnotationIdentifier]:
+        datum = self._get_sensor_frame_data_datum(frame_id=frame_id, sensor_name=sensor_name)
+        type_to_path = datum.image.annotations
+        available_annotation_types = {ANNOTATION_TYPE_MAP[k]: v for k, v in type_to_path.items()}
+
+        point_cache_folder = self._dataset_path / self.scene_name / "point_cache"
+        if BoundingBoxes3D in available_annotation_types and point_cache_folder.exists():
+            available_annotation_types[PointCaches] = "$".join(
+                [available_annotation_types[BoundingBoxes3D], sensor_name, frame_id]
+            )
+        return available_annotation_types
+
     def _decode_image_dimensions(self, sensor_name: SensorName, frame_id: FrameId) -> Tuple[int, int, int]:
         datum = self._get_sensor_frame_data_datum(frame_id=frame_id, sensor_name=sensor_name)
         return datum.image.height, datum.image.width, datum.image.channels

--- a/paralleldomain/decoding/dgp/v1/sensor_frame_decoder.py
+++ b/paralleldomain/decoding/dgp/v1/sensor_frame_decoder.py
@@ -708,6 +708,18 @@ class DGPRadarSensorFrameDecoder(DGPSensorFrameDecoder, RadarSensorFrameDecoder[
         self._decode_radar_point_cloud_data = lru_cache(maxsize=1)(self._decode_radar_point_cloud_data)
         self._decode_radar_energy_data = lru_cache(maxsize=1)(self._decode_radar_energy_data)
 
+    def _decode_available_annotation_types(
+        self, sensor_name: SensorName, frame_id: FrameId
+    ) -> Dict[AnnotationType, AnnotationIdentifier]:
+        datum = self._get_sensor_frame_data_datum(frame_id=frame_id, sensor_name=sensor_name)
+        if datum.radar_point_cloud:
+            type_to_path = datum.radar_point_cloud.annotations
+        else:
+            raise ValueError("RADAR data not found.")
+
+        available_annotation_types = {ANNOTATION_TYPE_MAP[k]: v for k, v in type_to_path.items()}
+        return available_annotation_types
+
     def _decode_radar_point_cloud_format(self, sensor_name: SensorName, frame_id: FrameId) -> List[str]:
         datum = self._get_sensor_frame_data_datum(frame_id=frame_id, sensor_name=sensor_name)
         return [

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="paralleldomain",
-    version="0.7.4",
+    version="0.7.5",
     author=", ".join(["Nisse Knudsen", "Phillip Thomas", "Lars Pandikow", "Michael Stanley"]),
     author_email=", ".join(
         [


### PR DESCRIPTION
in the current implementation getting annotation types for Radar and Lidar via _decode_available_annotation_types always triggers "if datum.image:" and returns empty list of annotation types. 

This fix overrides this method in child classes. **Tested on Lidar and Radar sensors** only.  