### PR TITLE
Fixed OpticalFlowTransformer._transform dtype issue by adding float->…

### DIFF
--- a/paralleldomain/encoding/dgp/transformer.py
+++ b/paralleldomain/encoding/dgp/transformer.py
@@ -29,7 +29,13 @@ class InstanceSegmentation2DTransformer(SemanticSegmentation2DTransformer):
 class OpticalFlowTransformer(MaskTransformer):
     @staticmethod
     def _transform(mask: np.ndarray) -> np.ndarray:
-        return encode_2int16_as_rgba8(mask)
+        # Constrain float between 0.0 and 1.0 then convert to uint16
+        height, width = mask.shape[:2]
+        mask /= 2 * np.array([width, height])
+        mask += 0.5
+        mask_2int16 = (mask * 65535).astype(np.uint16)
+
+        return encode_2int16_as_rgba8(mask_2int16)
 
 
 class SemanticSegmentation3DTransformer(MaskTransformer):

--- a/paralleldomain/utilities/mask.py
+++ b/paralleldomain/utilities/mask.py
@@ -41,7 +41,7 @@ def encode_rgb8_as_int32(mask: np.ndarray) -> np.ndarray:
 
 def encode_2int16_as_rgba8(mask: np.ndarray) -> np.ndarray:
     return np.concatenate(
-        [mask[..., [0]] >> 8, mask[..., [0]] & 0xFF, mask[..., [1]] >> 8, mask[..., [1]] & 0xFF], axis=-1
+        [mask[..., [0]] & 0xFF, mask[..., [0]] >> 8, mask[..., [1]] & 0xFF, mask[..., [1]] >> 8], axis=-1
     ).astype(np.uint8)
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="paralleldomain",
-    version="0.7.5",
+    version="0.7.6",
     author=", ".join(["Nisse Knudsen", "Phillip Thomas", "Lars Pandikow", "Michael Stanley"]),
     author_email=", ".join(
         [


### PR DESCRIPTION
…uint16 conversion. Fixed out-of-order channels in mask.encode_2int16_as_rgb8

Functionality constrains float value between 0.0 and 1.0 knowing the max values of +/- width and height, then converts to uint16 by multiplying by 65535.