### PR TITLE
Added check if annotation type in dataset in _encode_ontologies()

### DIFF
--- a/paralleldomain/encoding/dgp/v1/scene.py
+++ b/paralleldomain/encoding/dgp/v1/scene.py
@@ -1062,6 +1062,7 @@ class DGPSceneEncoder(SceneEncoder):
             ANNOTATION_TYPE_MAP_INV[a_type]: class_map_to_ontology_proto(class_map=self._scene.get_class_map(a_type))
             for a_type in self._annotation_types
             if a_type is not Annotation  # equiv: not implemented, yet!
+            and a_type in self._scene.available_annotation_types
         }
 
         output_path = self._output_path / DirectoryName.ONTOLOGY / ".json"


### PR DESCRIPTION
In DGPSceneEncoder._encode_camera_frame() we have checks to ignore annotations types passed by the user that are not in the dataset being encoded, which is useful because we do not always ship the same list of annotations to customers, and this keeps us from having to remove annotations not rendered from the encoder for different datasets. However, this same check was not done in _encode_ontologies(), where the inclusion of an annotation type not in the render would break the encoder. For consistency, it is best to add the check there.