### PR TITLE
Fixed: non-dgp annotations in ontology encoding. Local temp output di…

### DIFF
--- a/paralleldomain/common/dgp/v0/constants.py
+++ b/paralleldomain/common/dgp/v0/constants.py
@@ -31,6 +31,12 @@ ANNOTATION_TYPE_MAP_INV: Dict[Type[Annotation], str] = {
 POINT_FORMAT = ("X", "Y", "Z", "INTENSITY", "R", "G", "B", "RING", "TIMESTAMP")
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
+NON_DGP_ANNOTATIONS = {
+    AnnotationTypes.Albedo2D,
+    AnnotationTypes.MaterialProperties2D,
+    AnnotationTypes.MaterialProperties3D,
+}
+
 
 class DirectoryName:
     ALBEDO_2D: str = "base_color"


### PR DESCRIPTION
Fixes:

 - Albedo and Material properties don't appear in the scene JSONs under "ontologies", so they must be skipped in the _enocde_ontologies method or else the encoder fails. Created constant NON_DGP_ANNOTATIONS for this
 
 - Local output directories were not being created for all supported annotation types.
 
 - Added last_frame bool to the _encode_lidar_frame call for motion vectors 3d