### PR TITLE
Added auto load of distortion LUT CSV for cameras

### DIFF
--- a/paralleldomain/common/dgp/v1/src/dgp/proto/geometry_pb2.py
+++ b/paralleldomain/common/dgp/v1/src/dgp/proto/geometry_pb2.py
@@ -19,7 +19,6 @@ DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, "dgp.proto.geometry_pb2", globals())
 if _descriptor._USE_C_DESCRIPTORS == False:
-
     DESCRIPTOR._options = None
     _POINT3D._serialized_start = 39
     _POINT3D._serialized_end = 81

--- a/paralleldomain/decoding/cityscapes/sensor_frame_decoder.py
+++ b/paralleldomain/decoding/cityscapes/sensor_frame_decoder.py
@@ -68,7 +68,6 @@ class CityscapesCameraSensorFrameDecoder(CameraSensorFrameDecoder[None]):
     def _decode_available_annotation_types(
         self, sensor_name: SensorName, frame_id: FrameId
     ) -> Dict[AnnotationType, AnnotationIdentifier]:
-
         img_suffix = "_leftImg8bit"
         seg_map_suffix = "_gtFine_labelIds"
         # seg_map_suffix = "_gtFine_labelTrainIds"

--- a/paralleldomain/decoding/dgp/sensor_frame_decoder.py
+++ b/paralleldomain/decoding/dgp/sensor_frame_decoder.py
@@ -179,7 +179,6 @@ class DGPSensorFrameDecoder(SensorFrameDecoder[datetime], metaclass=abc.ABCMeta)
 
             box_list = []
             for box_dto in dto.annotations:
-
                 attr_parsed = {"iscrowd": box_dto.iscrowd}
                 for k, v in box_dto.attributes.items():
                     try:

--- a/paralleldomain/decoding/dgp/sensor_frame_decoder.py
+++ b/paralleldomain/decoding/dgp/sensor_frame_decoder.py
@@ -64,6 +64,7 @@ from paralleldomain.model.sensor import CameraModel, SensorExtrinsic, SensorIntr
 from paralleldomain.model.type_aliases import AnnotationIdentifier, FrameId, SceneName, SensorName
 from paralleldomain.utilities.any_path import AnyPath
 from paralleldomain.utilities.fsio import read_image, read_json, read_json_str, read_npz, read_png
+from paralleldomain.utilities.projection import DistortionLookup, DistortionLookupTable
 from paralleldomain.utilities.transformation import Transformation
 
 T = TypeVar("T")
@@ -534,6 +535,16 @@ class DGPCameraSensorFrameDecoder(DGPSensorFrameDecoder, CameraSensorFrameDecode
             fov=dto.fov,
             camera_model=camera_model,
         )
+
+    def _decode_distortion_lookup(self, sensor_name: SensorName, frame_id: FrameId) -> Optional[DistortionLookup]:
+        lookup = super()._decode_distortion_lookup(sensor_name=sensor_name, frame_id=frame_id)
+        if lookup is None:
+            lut_csv_path = self._dataset_path / self.scene_name / "calibration" / f"{sensor_name}.csv"
+            if lut_csv_path.exists():
+                with lut_csv_path.open() as f:
+                    lut = np.loadtxt(f, delimiter=",", dtype="float")
+                return DistortionLookupTable.from_ndarray(lut)
+        return None
 
 
 class PointInfo(Enum):

--- a/paralleldomain/decoding/dgp/sensor_frame_decoder.py
+++ b/paralleldomain/decoding/dgp/sensor_frame_decoder.py
@@ -543,8 +543,8 @@ class DGPCameraSensorFrameDecoder(DGPSensorFrameDecoder, CameraSensorFrameDecode
             if lut_csv_path.exists():
                 with lut_csv_path.open() as f:
                     lut = np.loadtxt(f, delimiter=",", dtype="float")
-                return DistortionLookupTable.from_ndarray(lut)
-        return None
+                lookup = DistortionLookupTable.from_ndarray(lut)
+        return lookup
 
 
 class PointInfo(Enum):

--- a/paralleldomain/decoding/dgp/v1/sensor_frame_decoder.py
+++ b/paralleldomain/decoding/dgp/v1/sensor_frame_decoder.py
@@ -724,8 +724,8 @@ class DGPCameraSensorFrameDecoder(DGPSensorFrameDecoder, CameraSensorFrameDecode
             if lut_csv_path.exists():
                 with lut_csv_path.open() as f:
                     lut = np.loadtxt(f, delimiter=",", dtype="float")
-                return DistortionLookupTable.from_ndarray(lut)
-        return None
+                lookup = DistortionLookupTable.from_ndarray(lut)
+        return lookup
 
 
 class DGPLidarSensorFrameDecoder(DGPSensorFrameDecoder, LidarSensorFrameDecoder[datetime]):

--- a/paralleldomain/decoding/dgp/v1/sensor_frame_decoder.py
+++ b/paralleldomain/decoding/dgp/v1/sensor_frame_decoder.py
@@ -207,7 +207,6 @@ class DGPSensorFrameDecoder(SensorFrameDecoder[datetime], metaclass=abc.ABCMeta)
 
             box_list = []
             for box_dto in dto.annotations:
-
                 # Decode generic attributes from and handle json encoded values
                 attr_decoded = _decode_attributes(attributes=box_dto.attributes)
                 # Read "iscrowd" and move them to attribute section in model

--- a/paralleldomain/decoding/sensor_frame_decoder.py
+++ b/paralleldomain/decoding/sensor_frame_decoder.py
@@ -198,13 +198,8 @@ class CameraSensorFrameDecoder(SensorFrameDecoder[TDateTime]):
         pass
 
     def _decode_distortion_lookup(self, sensor_name: SensorName, frame_id: FrameId) -> Optional[DistortionLookup]:
-        lut_csv_path = self._dataset_path / self.scene_name / "calibration" / f"{sensor_name}.csv"
         if sensor_name in self.settings.distortion_lookups:
             return self.settings.distortion_lookups[sensor_name]
-        elif lut_csv_path.exists():
-            with lut_csv_path.open() as f:
-                lut = np.loadtxt(f, delimiter=",", dtype="float")
-            return DistortionLookupTable.from_ndarray(lut)
         return None
 
     @abc.abstractmethod

--- a/paralleldomain/decoding/umd/map_decoder.py
+++ b/paralleldomain/decoding/umd/map_decoder.py
@@ -137,7 +137,6 @@ class UMDDecoder(MapDecoder):
     def decode_lane_segments(self) -> Dict[LaneSegmentId, LaneSegment]:
         segments = dict()
         for lane_segment_id, lane_segment in self.map_umd.lane_segments.items():
-
             reference_line = self.map_umd.edges[lane_segment.reference_line]
             reference_points = np.array([(p.x, p.y) for p in reference_line.points])
 

--- a/paralleldomain/encoding/dgp/v1/format/bounding_box_3d.py
+++ b/paralleldomain/encoding/dgp/v1/format/bounding_box_3d.py
@@ -25,7 +25,6 @@ class BoundingBox3DDGPV1Mixin(CommonDGPV1FormatMixin):
         sim_offset: float,
         save_binary: bool,
     ):
-
         output_path = self.get_file_output_path(
             scene_reference_timestamp=pipeline_item.scene_reference_timestamp,
             sim_offset=sim_offset,

--- a/paralleldomain/encoding/dgp/v1/format/scene.py
+++ b/paralleldomain/encoding/dgp/v1/format/scene.py
@@ -374,7 +374,6 @@ class SceneDGPV1Mixin(CommonDGPV1FormatMixin, DataAggregationMixin):
         return calib_dto_extrinsic
 
     def encode_camera_intrinsic(self, sensor_frame: CameraSensorFrame) -> geometry_pb2.CameraIntrinsics:
-
         intr = sensor_frame.intrinsic
         calib_dto_intrinsic = geometry_pb2.CameraIntrinsics(
             fx=intr.fx,

--- a/paralleldomain/encoding/generic_pipeline_builder.py
+++ b/paralleldomain/encoding/generic_pipeline_builder.py
@@ -182,7 +182,6 @@ class GenericPipelineBuilder(PipelineBuilder[TPipelineItem]):
         copy_all_available_sensors_and_annotations: bool = False,
         decoder_kwargs: Optional[Dict[str, Any]] = None,
     ):
-
         self.pipeline_item_type = pipeline_item_type
         self.workers = workers
         self.max_in_queue_size = max_in_queue_size

--- a/paralleldomain/model/dataset.py
+++ b/paralleldomain/model/dataset.py
@@ -372,7 +372,6 @@ class Dataset:
         max_queue_size: int = 8,
         max_workers: int = 4,
     ) -> Generator[Union[UnorderedScene, Scene], None, None]:
-
         """
         Returns a generator that yields all scenes from the dataset with the given names.
         If None is passed for scenes_names all scenes in this dataset are returned.

--- a/paralleldomain/model/unordered_scene.py
+++ b/paralleldomain/model/unordered_scene.py
@@ -294,7 +294,6 @@ class UnorderedScene(Generic[TDateTime]):
         max_queue_size: int = 8,
         max_workers: int = 4,
     ) -> Generator[Frame[TDateTime], None, None]:
-
         runenv = pypeln.sync
         if concurrent:
             if not shuffle:

--- a/paralleldomain/utilities/fsio.py
+++ b/paralleldomain/utilities/fsio.py
@@ -155,7 +155,6 @@ def read_flo(path: AnyPath):
     Reads optical flow files in the .flo format. Notably used for Flying Chairs:
     https://lmb.informatik.uni-freiburg.de/resources/datasets/FlyingChairs.en.html#flyingchairs"""
     with path.open(mode="rb") as fp:
-
         header = fp.read(4)
         if header.decode("utf-8") != "PIEH":
             raise Exception("Flow file header does not contain PIEH")

--- a/test_paralleldomain/model/test_annotation.py
+++ b/test_paralleldomain/model/test_annotation.py
@@ -172,7 +172,6 @@ class TestSensorFrame:
 
     @pytest.mark.skip
     def test_albedo_2d_loading(self, scene: Scene, dataset: Dataset):
-
         frame_ids = scene.frame_ids
         frame = scene.get_frame(frame_id=frame_ids[0])
 
@@ -191,7 +190,6 @@ class TestSensorFrame:
 
     @pytest.mark.skip
     def test_material_properties_2d_loading(self, scene: Scene, dataset: Dataset):
-
         frame_ids = scene.frame_ids
         frame = scene.get_frame(frame_id=frame_ids[0])
 

--- a/test_paralleldomain/model/test_sensor.py
+++ b/test_paralleldomain/model/test_sensor.py
@@ -7,6 +7,8 @@ from unittest import mock
 from paralleldomain import Scene
 from paralleldomain.decoding.common import DecoderSettings
 from paralleldomain.decoding.decoder import DatasetDecoder
+from paralleldomain.decoding.dgp.decoder import DGPDatasetDecoder as DGPDatasetDecoderV0
+from paralleldomain.decoding.dgp.v1.decoder import DGPDatasetDecoder as DGPDatasetDecoderV1
 from paralleldomain.model.annotation import AnnotationType
 from paralleldomain.model.class_mapping import ClassMap
 from paralleldomain.utilities.lazy_load_cache import LAZY_LOAD_CACHE
@@ -84,20 +86,26 @@ class TestSensorFrame:
         init_kwargs["settings"] = None
         no_lookup_decoder = decoder_cls(**init_kwargs)
         dataset = no_lookup_decoder.get_dataset()
-        sensor_frame = next(iter(dataset.get_sensor_frames(sensor_names=["camera_front"])))
-        distortion_lookup = sensor_frame.distortion_lookup
-        assert distortion_lookup is None
-
-        sensor_frame = next(iter(dataset.get_sensor_frames(sensor_names=["camera_rear"])))
-        distortion_lookup = sensor_frame.distortion_lookup
-        assert isinstance(distortion_lookup, DistortionLookupTable)
+        if isinstance(decoder, (DGPDatasetDecoderV0, DGPDatasetDecoderV1)):
+            calib_path = dataset._decoder.get_path() / dataset.scene_names[0] / "calibration"
+            for camera_name in dataset.camera_names:
+                sensor_frame = next(iter(dataset.get_sensor_frames(sensor_names=[camera_name])))
+                distortion_lookup = sensor_frame.distortion_lookup
+                if (calib_path / (camera_name + ".csv")).exists():
+                    assert isinstance(distortion_lookup, DistortionLookupTable)
+                else:
+                    assert distortion_lookup is None
+        else:
+            sensor_frame = next(iter(dataset.camera_frames))
+            distortion_lookup = sensor_frame.distortion_lookup
+            assert distortion_lookup is None
 
         no_lookup_decoder.lazy_load_cache.clear()
         fake_loopup = mock.MagicMock()
         init_kwargs["settings"] = DecoderSettings(distortion_lookups={sensor_frame.sensor_name: fake_loopup})
         with_lookup_decoder = decoder_cls(**init_kwargs)
         dataset = with_lookup_decoder.get_dataset()
-        sensor_frame = next(iter(dataset.get_sensor_frames(sensor_frame.sensor_name)))
+        sensor_frame = next(iter(dataset.get_sensor_frames(sensor_names=[sensor_frame.sensor_name])))
         distortion_lookup = sensor_frame.distortion_lookup
         assert distortion_lookup == fake_loopup
 

--- a/test_paralleldomain/model/test_sensor.py
+++ b/test_paralleldomain/model/test_sensor.py
@@ -10,6 +10,7 @@ from paralleldomain.decoding.decoder import DatasetDecoder
 from paralleldomain.model.annotation import AnnotationType
 from paralleldomain.model.class_mapping import ClassMap
 from paralleldomain.utilities.lazy_load_cache import LAZY_LOAD_CACHE
+from paralleldomain.utilities.projection import DistortionLookupTable
 
 
 def class_maps_do_match(map_a: Dict[AnnotationType, ClassMap], map_b: Dict[AnnotationType, ClassMap]):
@@ -82,17 +83,21 @@ class TestSensorFrame:
         init_kwargs = decoder.get_decoder_init_kwargs()
         init_kwargs["settings"] = None
         no_lookup_decoder = decoder_cls(**init_kwargs)
-        datast = no_lookup_decoder.get_dataset()
-        sensor_frame = next(iter(datast.camera_frames))
+        dataset = no_lookup_decoder.get_dataset()
+        sensor_frame = next(iter(dataset.get_sensor_frames(sensor_names=["camera_front"])))
         distortion_lookup = sensor_frame.distortion_lookup
         assert distortion_lookup is None
+
+        sensor_frame = next(iter(dataset.get_sensor_frames(sensor_names=["camera_rear"])))
+        distortion_lookup = sensor_frame.distortion_lookup
+        assert isinstance(distortion_lookup, DistortionLookupTable)
+
         no_lookup_decoder.lazy_load_cache.clear()
         fake_loopup = mock.MagicMock()
-
         init_kwargs["settings"] = DecoderSettings(distortion_lookups={sensor_frame.sensor_name: fake_loopup})
         with_lookup_decoder = decoder_cls(**init_kwargs)
         dataset = with_lookup_decoder.get_dataset()
-        sensor_frame = next(iter(dataset.camera_frames))
+        sensor_frame = next(iter(dataset.get_sensor_frames(sensor_frame.sensor_name)))
         distortion_lookup = sensor_frame.distortion_lookup
         assert distortion_lookup == fake_loopup
 


### PR DESCRIPTION
If user calls camera_frame.distortion_lookup and no DecoderSettings lookups are present, code will check for presence of distortion LUT for camera in scene's calibration folder and return a DistortionLookupTable object if it is found.

Otherwise, previous behavior is maintained.