### PR TITLE
Add lidar and 3D bounding box annotations to waymo open dataset

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
       - id: mixed-line-ending
   - repo: https://github.com/pycqa/isort
-    rev: 5.8.0
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort
@@ -39,8 +39,8 @@ repos:
       - id: blacken-docs
         additional_dependencies: [ black==20.8b1 ]
         args: [ --line-length=120 ]
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
-    hooks:
-      - id: flake8
-        args: [ "--max-line-length=120", "--ignore=E203,F401,F407,W503" ]
+  # - repo: https://gitlab.com/pycqa/flake8
+  #   rev: 3.8.4
+  #   hooks:
+  #     - id: flake8
+  #       args: [ "--max-line-length=120", "--ignore=E203,F401,F407,W503" ]

--- a/paralleldomain/decoding/waymo_open_dataset/common.py
+++ b/paralleldomain/decoding/waymo_open_dataset/common.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Generator, List, Optional, Tuple
 from paralleldomain.decoding.common import LazyLoadPropertyMixin, create_cache_key
 from paralleldomain.decoding.waymo_open_dataset.protos import camera_segmentation_pb2 as cs_pb2
 from paralleldomain.decoding.waymo_open_dataset.protos import dataset_pb2
+from paralleldomain.decoding.waymo_open_dataset.protos import label_pb2 as label_pb2
 from paralleldomain.model.annotation import AnnotationType, AnnotationTypes
 from paralleldomain.model.class_mapping import ClassDetail, ClassMap
 from paralleldomain.model.type_aliases import FrameId, SceneName, SensorName
@@ -357,6 +358,42 @@ WAYMO_SEMSEG_CLASSES = [
     ),
 ]
 
+WAYMO_3DBB_CLASSES = [
+    ClassDetail(
+        name="UNDEFINED",
+        id=0,
+        instanced=True,
+        meta=dict(),
+    ),
+    ClassDetail(
+        name="VEHICLE",
+        id=1,
+        instanced=True,
+        meta=dict(),
+    ),
+    ClassDetail(
+        name="PEDESTRIAN",
+        id=2,
+        instanced=True,
+        meta=dict(),
+    ),
+    ClassDetail(
+        name="SIGNT",
+        id=3,
+        instanced=True,
+        meta=dict(),
+    ),
+    ClassDetail(
+        name="CYCLIST",
+        id=4,
+        instanced=True,
+        meta=dict(),
+    ),
+]
+
 
 def decode_class_maps() -> Dict[AnnotationType, ClassMap]:
-    return {AnnotationTypes.SemanticSegmentation2D: ClassMap(classes=WAYMO_SEMSEG_CLASSES)}
+    return {
+        AnnotationTypes.SemanticSegmentation2D: ClassMap(classes=WAYMO_SEMSEG_CLASSES),
+        AnnotationTypes.BoundingBoxes3D: ClassMap(classes=WAYMO_3DBB_CLASSES),
+    }

--- a/paralleldomain/decoding/waymo_open_dataset/common.py
+++ b/paralleldomain/decoding/waymo_open_dataset/common.py
@@ -56,6 +56,8 @@ WAYMO_INDEX_TO_CAMERA_NAME = {
 
 WAYMO_CAMERA_NAME_TO_INDEX = {v: k for k, v in WAYMO_INDEX_TO_CAMERA_NAME.items()}
 
+WAYMO_USE_ALL_LIDAR_NAME = "all"
+
 WAYMO_INDEX_TO_LIDAR_NAME = {
     1: "TOP",
     2: "FRONT",
@@ -154,9 +156,6 @@ def get_cached_pre_calculated_scene_to_has_segmentation(
     if key in id_map:
         return id_map[key]
     return False
-
-
-# TODO: May need get_cached_pre_calculated_scene_to_has_point_cloud, not sure yet
 
 
 class WaymoFileAccessMixin(LazyLoadPropertyMixin):

--- a/paralleldomain/decoding/waymo_open_dataset/common.py
+++ b/paralleldomain/decoding/waymo_open_dataset/common.py
@@ -60,6 +60,7 @@ WAYMO_CAMERA_NAME_TO_INDEX = {v: k for k, v in WAYMO_INDEX_TO_CAMERA_NAME.items(
 WAYMO_USE_ALL_LIDAR_NAME = "all"
 
 WAYMO_INDEX_TO_LIDAR_NAME = {
+    0: "UNKNOWN",
     1: "TOP",
     2: "FRONT",
     3: "SIDE_LEFT",
@@ -378,7 +379,7 @@ WAYMO_3DBB_CLASSES = [
         meta=dict(),
     ),
     ClassDetail(
-        name="SIGNT",
+        name="SIGN",
         id=3,
         instanced=True,
         meta=dict(),

--- a/paralleldomain/decoding/waymo_open_dataset/common.py
+++ b/paralleldomain/decoding/waymo_open_dataset/common.py
@@ -156,6 +156,9 @@ def get_cached_pre_calculated_scene_to_has_segmentation(
     return False
 
 
+# TODO: May need get_cached_pre_calculated_scene_to_has_point_cloud, not sure yet
+
+
 class WaymoFileAccessMixin(LazyLoadPropertyMixin):
     def __init__(self, record_path: AnyPath):
         self.record_path = record_path

--- a/paralleldomain/decoding/waymo_open_dataset/common.py
+++ b/paralleldomain/decoding/waymo_open_dataset/common.py
@@ -173,7 +173,15 @@ class WaymoFileAccessMixin(LazyLoadPropertyMixin):
         )
 
 
-WAYMO_CLASSES = [
+WAYMO_BBOX3D_CLASSES = {
+    0: "unknown",
+    1: "vehicle",
+    2: "pedestrian",
+    3: "sign",
+    4: "cyclist",
+}
+
+WAYMO_SEMSEG_CLASSES = [
     ClassDetail(
         name="UNDEFINED",
         id=cs_pb2.CameraSegmentation.TYPE_UNDEFINED,
@@ -352,4 +360,4 @@ WAYMO_CLASSES = [
 
 
 def decode_class_maps() -> Dict[AnnotationType, ClassMap]:
-    return {AnnotationTypes.SemanticSegmentation2D: ClassMap(classes=WAYMO_CLASSES)}
+    return {AnnotationTypes.SemanticSegmentation2D: ClassMap(classes=WAYMO_SEMSEG_CLASSES)}

--- a/paralleldomain/decoding/waymo_open_dataset/decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/decoder.py
@@ -9,7 +9,7 @@ from paralleldomain.decoding.frame_decoder import FrameDecoder
 from paralleldomain.decoding.sensor_decoder import CameraSensorDecoder, LidarSensorDecoder, RadarSensorDecoder
 from paralleldomain.decoding.waymo_open_dataset.common import (
     decode_class_maps,
-    get_cached_pre_calcualted_scene_to_frame_info,
+    get_cached_pre_calculated_scene_to_frame_info,
     get_record_iterator,
 )
 from paralleldomain.decoding.waymo_open_dataset.frame_decoder import WaymoOpenDatasetFrameDecoder
@@ -60,7 +60,7 @@ class WaymoOpenDatasetDecoder(DatasetDecoder):
 
     def _decode_scene_names(self) -> List[SceneName]:
         if self.use_precalculated_maps and self.split_name in ["training", "validation"]:
-            id_map = get_cached_pre_calcualted_scene_to_frame_info(
+            id_map = get_cached_pre_calculated_scene_to_frame_info(
                 lazy_load_cache=self.lazy_load_cache, dataset_name=self.dataset_name, split_name=self.split_name
             )
             return sorted(list(id_map.keys()))
@@ -108,7 +108,7 @@ class WaymoOpenDatasetSceneDecoder(SceneDecoder[datetime]):
 
     def _decode_frame_id_set(self, scene_name: SceneName) -> Set[FrameId]:
         if self.use_precalculated_maps and self.split_name in ["training", "validation"]:
-            id_map = get_cached_pre_calcualted_scene_to_frame_info(
+            id_map = get_cached_pre_calculated_scene_to_frame_info(
                 lazy_load_cache=self.lazy_load_cache, dataset_name=self.dataset_name, split_name=self.split_name
             )
             if scene_name in id_map:
@@ -163,7 +163,7 @@ class WaymoOpenDatasetSceneDecoder(SceneDecoder[datetime]):
     def _decode_frame_id_to_date_time_map(self, scene_name: SceneName) -> Dict[FrameId, datetime]:
         frame_id_to_date_time_map = dict()
         if self.use_precalculated_maps and self.split_name in ["training", "validation"]:
-            id_map = get_cached_pre_calcualted_scene_to_frame_info(
+            id_map = get_cached_pre_calculated_scene_to_frame_info(
                 lazy_load_cache=self.lazy_load_cache, dataset_name=self.dataset_name, split_name=self.split_name
             )
             for elem in id_map[scene_name]:

--- a/paralleldomain/decoding/waymo_open_dataset/decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/decoder.py
@@ -185,6 +185,7 @@ class WaymoOpenDatasetSceneDecoder(SceneDecoder[datetime]):
             settings=self.settings,
             use_precalculated_maps=self.use_precalculated_maps,
             split_name=self.split_name,
+            use_all_lidar=self.use_all_lidar,
         )
 
     def _decode_frame_id_to_date_time_map(self, scene_name: SceneName) -> Dict[FrameId, datetime]:

--- a/paralleldomain/decoding/waymo_open_dataset/decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/decoder.py
@@ -76,7 +76,11 @@ class WaymoOpenDatasetDecoder(DatasetDecoder):
     def _decode_dataset_metadata(self) -> DatasetMeta:
         return DatasetMeta(
             name=self.dataset_name,
-            available_annotation_types=[AnnotationTypes.SemanticSegmentation2D, AnnotationTypes.InstanceSegmentation2D],
+            available_annotation_types=[
+                AnnotationTypes.SemanticSegmentation2D,
+                AnnotationTypes.InstanceSegmentation2D,
+                AnnotationTypes.BoundingBoxes3D,
+            ],
             custom_attributes=dict(),
         )
 
@@ -131,7 +135,8 @@ class WaymoOpenDatasetSceneDecoder(SceneDecoder[datetime]):
         return list(WAYMO_INDEX_TO_CAMERA_NAME.values())[1:]
 
     def _decode_lidar_names(self, scene_name: SceneName) -> List[SensorName]:
-        return list(WAYMO_INDEX_TO_LIDAR_NAME.values())
+        return ["lidar"]
+        # return list(WAYMO_INDEX_TO_LIDAR_NAME.values())
 
     def _decode_class_maps(self, scene_name: SceneName) -> Dict[AnnotationType, ClassMap]:
         return decode_class_maps()

--- a/paralleldomain/decoding/waymo_open_dataset/decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/decoder.py
@@ -10,6 +10,7 @@ from paralleldomain.decoding.sensor_decoder import CameraSensorDecoder, LidarSen
 from paralleldomain.decoding.waymo_open_dataset.common import (
     WAYMO_INDEX_TO_CAMERA_NAME,
     WAYMO_INDEX_TO_LIDAR_NAME,
+    WAYMO_USE_ALL_LIDAR_NAME,
     decode_class_maps,
     get_cached_pre_calculated_scene_to_frame_info,
     get_record_iterator,
@@ -134,14 +135,16 @@ class WaymoOpenDatasetSceneDecoder(SceneDecoder[datetime]):
         return set(frame_ids)
 
     def _decode_sensor_names(self, scene_name: SceneName) -> List[SensorName]:
-        return self.get_camera_names(scene_name=scene_name)
+        cam_names = self.get_camera_names(scene_name=scene_name)
+        lidar_names = self.get_lidar_names(scene_name=scene_name)
+        return cam_names + lidar_names
 
     def _decode_camera_names(self, scene_name: SceneName) -> List[SensorName]:
         return list(WAYMO_INDEX_TO_CAMERA_NAME.values())
 
     def _decode_lidar_names(self, scene_name: SceneName) -> List[SensorName]:
         if self.use_all_lidar:
-            return ["lidar"]
+            return [WAYMO_USE_ALL_LIDAR_NAME]
         else:
             return list(WAYMO_INDEX_TO_LIDAR_NAME.values())
 

--- a/paralleldomain/decoding/waymo_open_dataset/decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/decoder.py
@@ -8,12 +8,17 @@ from paralleldomain.decoding.decoder import DatasetDecoder, SceneDecoder, TDateT
 from paralleldomain.decoding.frame_decoder import FrameDecoder
 from paralleldomain.decoding.sensor_decoder import CameraSensorDecoder, LidarSensorDecoder, RadarSensorDecoder
 from paralleldomain.decoding.waymo_open_dataset.common import (
+    WAYMO_INDEX_TO_CAMERA_NAME,
+    WAYMO_INDEX_TO_LIDAR_NAME,
     decode_class_maps,
     get_cached_pre_calculated_scene_to_frame_info,
     get_record_iterator,
 )
 from paralleldomain.decoding.waymo_open_dataset.frame_decoder import WaymoOpenDatasetFrameDecoder
-from paralleldomain.decoding.waymo_open_dataset.sensor_decoder import WaymoOpenDatasetCameraSensorDecoder
+from paralleldomain.decoding.waymo_open_dataset.sensor_decoder import (
+    WaymoOpenDatasetCameraSensorDecoder,
+    WaymoOpenDatasetLidarSensorDecoder,
+)
 from paralleldomain.model.annotation import AnnotationType, AnnotationTypes
 from paralleldomain.model.class_mapping import ClassDetail, ClassMap
 from paralleldomain.model.dataset import DatasetMeta
@@ -123,10 +128,10 @@ class WaymoOpenDatasetSceneDecoder(SceneDecoder[datetime]):
         return self.get_camera_names(scene_name=scene_name)
 
     def _decode_camera_names(self, scene_name: SceneName) -> List[SensorName]:
-        return ["FRONT", "FRONT_LEFT", "FRONT_RIGHT", "SIDE_LEFT", "SIDE_RIGHT"]
+        return list(WAYMO_INDEX_TO_CAMERA_NAME.values())[1:]
 
     def _decode_lidar_names(self, scene_name: SceneName) -> List[SensorName]:
-        raise NotImplementedError()
+        return list(WAYMO_INDEX_TO_LIDAR_NAME.values())
 
     def _decode_class_maps(self, scene_name: SceneName) -> Dict[AnnotationType, ClassMap]:
         return decode_class_maps()
@@ -146,7 +151,14 @@ class WaymoOpenDatasetSceneDecoder(SceneDecoder[datetime]):
     def _create_lidar_sensor_decoder(
         self, scene_name: SceneName, lidar_name: SensorName, dataset_name: str
     ) -> LidarSensorDecoder[datetime]:
-        raise ValueError("Directory decoder does not support lidar data!")
+        return WaymoOpenDatasetLidarSensorDecoder(
+            dataset_name=self.dataset_name,
+            dataset_path=self._dataset_path,
+            scene_name=scene_name,
+            settings=self.settings,
+            split_name=self.split_name,
+            use_precalculated_maps=self.use_precalculated_maps,
+        )
 
     def _create_frame_decoder(
         self, scene_name: SceneName, frame_id: FrameId, dataset_name: str

--- a/paralleldomain/decoding/waymo_open_dataset/decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/decoder.py
@@ -37,6 +37,7 @@ class WaymoOpenDatasetDecoder(DatasetDecoder):
         split_name: str,
         settings: Optional[DecoderSettings] = None,
         use_precalculated_maps: bool = True,
+        use_all_lidar: bool = True,
         **kwargs,
     ):
         self._init_kwargs = dict(
@@ -47,6 +48,7 @@ class WaymoOpenDatasetDecoder(DatasetDecoder):
         )
         self._dataset_path: AnyPath = AnyPath(dataset_path) / split_name
         self.split_name = split_name
+        self.use_all_lidar = use_all_lidar
         self.use_precalculated_maps = use_precalculated_maps
         dataset_name = f"Waymo Open Dataset - {split_name}"
         super().__init__(dataset_name=dataset_name, settings=settings, **kwargs)
@@ -58,6 +60,7 @@ class WaymoOpenDatasetDecoder(DatasetDecoder):
             settings=self.settings,
             split_name=self.split_name,
             use_precalculated_maps=self.use_precalculated_maps,
+            use_all_lidar=self.use_all_lidar,
         )
 
     def _decode_unordered_scene_names(self) -> List[SceneName]:
@@ -103,8 +106,10 @@ class WaymoOpenDatasetSceneDecoder(SceneDecoder[datetime]):
         settings: DecoderSettings,
         use_precalculated_maps: bool,
         split_name: str,
+        use_all_lidar: bool,
     ):
         self.split_name = split_name
+        self.use_all_lidar = use_all_lidar
         self._dataset_path: AnyPath = AnyPath(dataset_path)
         self.use_precalculated_maps = use_precalculated_maps
         super().__init__(dataset_name=dataset_name, settings=settings)
@@ -132,11 +137,13 @@ class WaymoOpenDatasetSceneDecoder(SceneDecoder[datetime]):
         return self.get_camera_names(scene_name=scene_name)
 
     def _decode_camera_names(self, scene_name: SceneName) -> List[SensorName]:
-        return list(WAYMO_INDEX_TO_CAMERA_NAME.values())[1:]
+        return list(WAYMO_INDEX_TO_CAMERA_NAME.values())
 
     def _decode_lidar_names(self, scene_name: SceneName) -> List[SensorName]:
-        return ["lidar"]
-        # return list(WAYMO_INDEX_TO_LIDAR_NAME.values())
+        if self.use_all_lidar:
+            return ["lidar"]
+        else:
+            return list(WAYMO_INDEX_TO_LIDAR_NAME.values())
 
     def _decode_class_maps(self, scene_name: SceneName) -> Dict[AnnotationType, ClassMap]:
         return decode_class_maps()

--- a/paralleldomain/decoding/waymo_open_dataset/decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/decoder.py
@@ -39,6 +39,7 @@ class WaymoOpenDatasetDecoder(DatasetDecoder):
         settings: Optional[DecoderSettings] = None,
         use_precalculated_maps: bool = True,
         use_all_lidar: bool = True,
+        include_second_returns: bool = True,
         **kwargs,
     ):
         self._init_kwargs = dict(
@@ -50,6 +51,7 @@ class WaymoOpenDatasetDecoder(DatasetDecoder):
         self._dataset_path: AnyPath = AnyPath(dataset_path) / split_name
         self.split_name = split_name
         self.use_all_lidar = use_all_lidar
+        self.include_second_returns = include_second_returns
         self.use_precalculated_maps = use_precalculated_maps
         dataset_name = f"Waymo Open Dataset - {split_name}"
         super().__init__(dataset_name=dataset_name, settings=settings, **kwargs)
@@ -62,6 +64,7 @@ class WaymoOpenDatasetDecoder(DatasetDecoder):
             split_name=self.split_name,
             use_precalculated_maps=self.use_precalculated_maps,
             use_all_lidar=self.use_all_lidar,
+            include_second_returns=self.include_second_returns,
         )
 
     def _decode_unordered_scene_names(self) -> List[SceneName]:
@@ -107,9 +110,11 @@ class WaymoOpenDatasetSceneDecoder(SceneDecoder[datetime]):
         settings: DecoderSettings,
         use_precalculated_maps: bool,
         split_name: str,
+        include_second_returns: bool,
         use_all_lidar: bool,
     ):
         self.split_name = split_name
+        self.include_second_returns = include_second_returns
         self.use_all_lidar = use_all_lidar
         self._dataset_path: AnyPath = AnyPath(dataset_path)
         self.use_precalculated_maps = use_precalculated_maps
@@ -173,6 +178,7 @@ class WaymoOpenDatasetSceneDecoder(SceneDecoder[datetime]):
             settings=self.settings,
             split_name=self.split_name,
             use_precalculated_maps=self.use_precalculated_maps,
+            include_second_returns=self.include_second_returns,
         )
 
     def _create_frame_decoder(
@@ -186,6 +192,7 @@ class WaymoOpenDatasetSceneDecoder(SceneDecoder[datetime]):
             use_precalculated_maps=self.use_precalculated_maps,
             split_name=self.split_name,
             use_all_lidar=self.use_all_lidar,
+            include_second_returns=self.include_second_returns,
         )
 
     def _decode_frame_id_to_date_time_map(self, scene_name: SceneName) -> Dict[FrameId, datetime]:

--- a/paralleldomain/decoding/waymo_open_dataset/decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/decoder.py
@@ -9,7 +9,6 @@ from paralleldomain.decoding.frame_decoder import FrameDecoder
 from paralleldomain.decoding.sensor_decoder import CameraSensorDecoder, LidarSensorDecoder, RadarSensorDecoder
 from paralleldomain.decoding.waymo_open_dataset.common import (
     WAYMO_INDEX_TO_CAMERA_NAME,
-    WAYMO_INDEX_TO_LIDAR_NAME,
     WAYMO_USE_ALL_LIDAR_NAME,
     decode_class_maps,
     get_cached_pre_calculated_scene_to_frame_info,
@@ -38,7 +37,6 @@ class WaymoOpenDatasetDecoder(DatasetDecoder):
         split_name: str,
         settings: Optional[DecoderSettings] = None,
         use_precalculated_maps: bool = True,
-        use_all_lidar: bool = True,
         include_second_returns: bool = True,
         **kwargs,
     ):
@@ -50,7 +48,6 @@ class WaymoOpenDatasetDecoder(DatasetDecoder):
         )
         self._dataset_path: AnyPath = AnyPath(dataset_path) / split_name
         self.split_name = split_name
-        self.use_all_lidar = use_all_lidar
         self.include_second_returns = include_second_returns
         self.use_precalculated_maps = use_precalculated_maps
         dataset_name = f"Waymo Open Dataset - {split_name}"
@@ -63,7 +60,6 @@ class WaymoOpenDatasetDecoder(DatasetDecoder):
             settings=self.settings,
             split_name=self.split_name,
             use_precalculated_maps=self.use_precalculated_maps,
-            use_all_lidar=self.use_all_lidar,
             include_second_returns=self.include_second_returns,
         )
 
@@ -111,11 +107,9 @@ class WaymoOpenDatasetSceneDecoder(SceneDecoder[datetime]):
         use_precalculated_maps: bool,
         split_name: str,
         include_second_returns: bool,
-        use_all_lidar: bool,
     ):
         self.split_name = split_name
         self.include_second_returns = include_second_returns
-        self.use_all_lidar = use_all_lidar
         self._dataset_path: AnyPath = AnyPath(dataset_path)
         self.use_precalculated_maps = use_precalculated_maps
         super().__init__(dataset_name=dataset_name, settings=settings)
@@ -148,10 +142,7 @@ class WaymoOpenDatasetSceneDecoder(SceneDecoder[datetime]):
         return list(WAYMO_INDEX_TO_CAMERA_NAME.values())
 
     def _decode_lidar_names(self, scene_name: SceneName) -> List[SensorName]:
-        if self.use_all_lidar:
-            return [WAYMO_USE_ALL_LIDAR_NAME]
-        else:
-            return list(WAYMO_INDEX_TO_LIDAR_NAME.values())
+        return [WAYMO_USE_ALL_LIDAR_NAME]
 
     def _decode_class_maps(self, scene_name: SceneName) -> Dict[AnnotationType, ClassMap]:
         return decode_class_maps()
@@ -191,7 +182,6 @@ class WaymoOpenDatasetSceneDecoder(SceneDecoder[datetime]):
             settings=self.settings,
             use_precalculated_maps=self.use_precalculated_maps,
             split_name=self.split_name,
-            use_all_lidar=self.use_all_lidar,
             include_second_returns=self.include_second_returns,
         )
 

--- a/paralleldomain/decoding/waymo_open_dataset/frame_decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/frame_decoder.py
@@ -45,15 +45,18 @@ class WaymoOpenDatasetFrameDecoder(FrameDecoder[datetime], WaymoFileAccessMixin)
         raise ValueError("Loading from directory does not support ego pose!")
 
     def _decode_available_sensor_names(self, frame_id: FrameId) -> List[SensorName]:
-        return self.get_camera_names(frame_id=frame_id)
+        cam_names = self.get_camera_names(frame_id=frame_id)
+        lidar_names = self.get_lidar_names(frame_id=frame_id)
+        return cam_names + lidar_names
 
     def _decode_available_camera_names(self, frame_id: FrameId) -> List[SensorName]:
         record = self.get_record_at(frame_id=frame_id)
         return [WAYMO_INDEX_TO_CAMERA_NAME[img.name] for img in record.images]
 
     def _decode_available_lidar_names(self, frame_id: FrameId) -> List[SensorName]:
-        record = self.get_record_at(frame_id=frame_id)
-        return [WAYMO_INDEX_TO_LIDAR_NAME[laser.name] for laser in record.lasers]
+        # record = self.get_record_at(frame_id=frame_id)
+        # return [WAYMO_INDEX_TO_LIDAR_NAME[laser.name] for laser in record.lasers]
+        return ["lidar"]
 
     def _decode_datetime(self, frame_id: FrameId) -> datetime:
         record = self.get_record_at(frame_id=frame_id)
@@ -93,12 +96,12 @@ class WaymoOpenDatasetFrameDecoder(FrameDecoder[datetime], WaymoFileAccessMixin)
         raise ValueError("This dataset has no radar data!")
 
     def _create_radar_sensor_frame_decoder(self) -> RadarSensorFrameDecoder[TDateTime]:
-        raise ValueError("his dataset has no radar data!")
+        raise ValueError("This dataset has no radar data!")
 
     def _decode_radar_sensor_frame(
         self, decoder: RadarSensorFrameDecoder[TDateTime], frame_id: FrameId, sensor_name: SensorName
     ) -> RadarSensorFrame[TDateTime]:
-        raise ValueError("his dataset has no radar data!")
+        raise ValueError("This dataset has no radar data!")
 
     def _decode_metadata(self, frame_id: FrameId) -> Dict[str, Any]:
         record = self.get_record_at(frame_id=frame_id)

--- a/paralleldomain/decoding/waymo_open_dataset/frame_decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/frame_decoder.py
@@ -35,10 +35,12 @@ class WaymoOpenDatasetFrameDecoder(FrameDecoder[datetime], WaymoFileAccessMixin)
         settings: DecoderSettings,
         use_precalculated_maps: bool,
         split_name: str,
+        use_all_lidar: bool,
     ):
         FrameDecoder.__init__(self=self, dataset_name=dataset_name, scene_name=scene_name, settings=settings)
         WaymoFileAccessMixin.__init__(self=self, record_path=dataset_path / scene_name)
         self.split_name = split_name
+        self.use_all_lidar = use_all_lidar
         self.use_precalculated_maps = use_precalculated_maps
         self.dataset_path = dataset_path
 

--- a/paralleldomain/decoding/waymo_open_dataset/frame_decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/frame_decoder.py
@@ -15,7 +15,10 @@ from paralleldomain.decoding.waymo_open_dataset.common import (
     WAYMO_INDEX_TO_LIDAR_NAME,
     WaymoFileAccessMixin,
 )
-from paralleldomain.decoding.waymo_open_dataset.sensor_frame_decoder import WaymoOpenDatasetCameraSensorFrameDecoder
+from paralleldomain.decoding.waymo_open_dataset.sensor_frame_decoder import (
+    WaymoOpenDatasetCameraSensorFrameDecoder,
+    WaymoOpenDatasetLidarSensorFrameDecoder,
+)
 from paralleldomain.model.ego import EgoPose
 from paralleldomain.model.sensor import CameraSensorFrame, LidarSensorFrame, RadarSensorFrame
 from paralleldomain.model.type_aliases import FrameId, SceneName, SensorName
@@ -72,12 +75,19 @@ class WaymoOpenDatasetFrameDecoder(FrameDecoder[datetime], WaymoFileAccessMixin)
         return CameraSensorFrame[datetime](sensor_name=sensor_name, frame_id=frame_id, decoder=decoder)
 
     def _create_lidar_sensor_frame_decoder(self) -> LidarSensorFrameDecoder[datetime]:
-        raise NotImplementedError()
+        return WaymoOpenDatasetLidarSensorFrameDecoder(
+            dataset_name=self.dataset_name,
+            scene_name=self.scene_name,
+            dataset_path=self.dataset_path,
+            settings=self.settings,
+            use_precalculated_maps=self.use_precalculated_maps,
+            split_name=self.split_name,
+        )
 
     def _decode_lidar_sensor_frame(
         self, decoder: LidarSensorFrameDecoder[datetime], frame_id: FrameId, sensor_name: SensorName
     ) -> LidarSensorFrame[datetime]:
-        raise NotImplementedError()
+        return LidarSensorFrame[datetime](sensor_name=sensor_name, frame_id=frame_id, decoder=decoder)
 
     def _decode_available_radar_names(self, frame_id: FrameId) -> List[SensorName]:
         raise ValueError("This dataset has no radar data!")

--- a/paralleldomain/decoding/waymo_open_dataset/frame_decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/frame_decoder.py
@@ -35,11 +35,13 @@ class WaymoOpenDatasetFrameDecoder(FrameDecoder[datetime], WaymoFileAccessMixin)
         settings: DecoderSettings,
         use_precalculated_maps: bool,
         split_name: str,
+        include_second_returns: bool,
         use_all_lidar: bool,
     ):
         FrameDecoder.__init__(self=self, dataset_name=dataset_name, scene_name=scene_name, settings=settings)
         WaymoFileAccessMixin.__init__(self=self, record_path=dataset_path / scene_name)
         self.split_name = split_name
+        self.include_second_returns = include_second_returns
         self.use_all_lidar = use_all_lidar
         self.use_precalculated_maps = use_precalculated_maps
         self.dataset_path = dataset_path
@@ -89,6 +91,7 @@ class WaymoOpenDatasetFrameDecoder(FrameDecoder[datetime], WaymoFileAccessMixin)
             settings=self.settings,
             use_precalculated_maps=self.use_precalculated_maps,
             split_name=self.split_name,
+            include_second_returns=self.include_second_returns,
         )
 
     def _decode_lidar_sensor_frame(

--- a/paralleldomain/decoding/waymo_open_dataset/frame_decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/frame_decoder.py
@@ -10,7 +10,11 @@ from paralleldomain.decoding.sensor_frame_decoder import (
     LidarSensorFrameDecoder,
     RadarSensorFrameDecoder,
 )
-from paralleldomain.decoding.waymo_open_dataset.common import WAYMO_INDEX_TO_CAMERA_NAME, WaymoFileAccessMixin
+from paralleldomain.decoding.waymo_open_dataset.common import (
+    WAYMO_INDEX_TO_CAMERA_NAME,
+    WAYMO_INDEX_TO_LIDAR_NAME,
+    WaymoFileAccessMixin,
+)
 from paralleldomain.decoding.waymo_open_dataset.sensor_frame_decoder import WaymoOpenDatasetCameraSensorFrameDecoder
 from paralleldomain.model.ego import EgoPose
 from paralleldomain.model.sensor import CameraSensorFrame, LidarSensorFrame, RadarSensorFrame
@@ -45,7 +49,8 @@ class WaymoOpenDatasetFrameDecoder(FrameDecoder[datetime], WaymoFileAccessMixin)
         return [WAYMO_INDEX_TO_CAMERA_NAME[img.name] for img in record.images]
 
     def _decode_available_lidar_names(self, frame_id: FrameId) -> List[SensorName]:
-        raise NotImplementedError()
+        record = self.get_record_at(frame_id=frame_id)
+        return [WAYMO_INDEX_TO_LIDAR_NAME[laser.name] for laser in record.lasers]
 
     def _decode_datetime(self, frame_id: FrameId) -> datetime:
         record = self.get_record_at(frame_id=frame_id)

--- a/paralleldomain/decoding/waymo_open_dataset/frame_decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/frame_decoder.py
@@ -12,7 +12,6 @@ from paralleldomain.decoding.sensor_frame_decoder import (
 )
 from paralleldomain.decoding.waymo_open_dataset.common import (
     WAYMO_INDEX_TO_CAMERA_NAME,
-    WAYMO_INDEX_TO_LIDAR_NAME,
     WAYMO_USE_ALL_LIDAR_NAME,
     WaymoFileAccessMixin,
 )
@@ -36,13 +35,11 @@ class WaymoOpenDatasetFrameDecoder(FrameDecoder[datetime], WaymoFileAccessMixin)
         use_precalculated_maps: bool,
         split_name: str,
         include_second_returns: bool,
-        use_all_lidar: bool,
     ):
         FrameDecoder.__init__(self=self, dataset_name=dataset_name, scene_name=scene_name, settings=settings)
         WaymoFileAccessMixin.__init__(self=self, record_path=dataset_path / scene_name)
         self.split_name = split_name
         self.include_second_returns = include_second_returns
-        self.use_all_lidar = use_all_lidar
         self.use_precalculated_maps = use_precalculated_maps
         self.dataset_path = dataset_path
 
@@ -59,10 +56,7 @@ class WaymoOpenDatasetFrameDecoder(FrameDecoder[datetime], WaymoFileAccessMixin)
         return [WAYMO_INDEX_TO_CAMERA_NAME[img.name] for img in record.images]
 
     def _decode_available_lidar_names(self, frame_id: FrameId) -> List[SensorName]:
-        if self.use_all_lidar:
-            return [WAYMO_USE_ALL_LIDAR_NAME]
-        else:
-            return list(WAYMO_INDEX_TO_LIDAR_NAME.values())
+        return [WAYMO_USE_ALL_LIDAR_NAME]
 
     def _decode_datetime(self, frame_id: FrameId) -> datetime:
         record = self.get_record_at(frame_id=frame_id)

--- a/paralleldomain/decoding/waymo_open_dataset/frame_decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/frame_decoder.py
@@ -13,6 +13,7 @@ from paralleldomain.decoding.sensor_frame_decoder import (
 from paralleldomain.decoding.waymo_open_dataset.common import (
     WAYMO_INDEX_TO_CAMERA_NAME,
     WAYMO_INDEX_TO_LIDAR_NAME,
+    WAYMO_USE_ALL_LIDAR_NAME,
     WaymoFileAccessMixin,
 )
 from paralleldomain.decoding.waymo_open_dataset.sensor_frame_decoder import (
@@ -54,9 +55,10 @@ class WaymoOpenDatasetFrameDecoder(FrameDecoder[datetime], WaymoFileAccessMixin)
         return [WAYMO_INDEX_TO_CAMERA_NAME[img.name] for img in record.images]
 
     def _decode_available_lidar_names(self, frame_id: FrameId) -> List[SensorName]:
-        # record = self.get_record_at(frame_id=frame_id)
-        # return [WAYMO_INDEX_TO_LIDAR_NAME[laser.name] for laser in record.lasers]
-        return ["lidar"]
+        if self.use_all_lidar:
+            return [WAYMO_USE_ALL_LIDAR_NAME]
+        else:
+            return list(WAYMO_INDEX_TO_LIDAR_NAME.values())
 
     def _decode_datetime(self, frame_id: FrameId) -> datetime:
         record = self.get_record_at(frame_id=frame_id)

--- a/paralleldomain/decoding/waymo_open_dataset/frame_utils.py
+++ b/paralleldomain/decoding/waymo_open_dataset/frame_utils.py
@@ -104,7 +104,7 @@ def convert_range_image_to_cartesian(frame, range_images, range_image_top_pose, 
 
     Returns:
       dict of {laser_name, (H, W, D)} range images in Cartesian coordinates.
-        5 fields are [intensity, elongation, x, y, z]
+        5 fields are [x, y, z, intensity, elongation]
     """
     cartesian_range_images = {}
     frame_pose = np.reshape(np.array(frame.pose.transform), [4, 4])
@@ -151,7 +151,7 @@ def convert_range_image_to_cartesian(frame, range_images, range_image_top_pose, 
         range_image_cartesian = np.squeeze(range_image_cartesian, axis=0)
 
         # Note: we are not currently keeping range because it's repetitive with x,y,z., but it is available here
-        range_image_cartesian = np.concatenate([range_image_tensor[..., 1:3], range_image_cartesian], axis=-1)
+        range_image_cartesian = np.concatenate([range_image_cartesian, range_image_tensor[..., 1:3]], axis=-1)
 
         cartesian_range_images[c.name] = range_image_cartesian
 
@@ -171,7 +171,7 @@ def convert_range_image_to_point_cloud(frame, range_images, range_image_top_pose
 
     Returns:
       points: {[N, 5]} list of 3d lidar points of length 5 (number of lidars).
-        5 fields are [intensity, elongation, x, y, z]
+        5 fields are [x, y, z, intensity, elongation]
     """
     calibrations = sorted(frame.context.laser_calibrations, key=lambda c: c.name)
     points = []

--- a/paralleldomain/decoding/waymo_open_dataset/frame_utils.py
+++ b/paralleldomain/decoding/waymo_open_dataset/frame_utils.py
@@ -92,7 +92,7 @@ def parse_range_image_and_camera_projection(
     return range_images, seg_labels, range_image_top_pose
 
 
-def convert_range_image_to_cartesian(frame, range_images, range_image_top_pose, ri_index=0, keep_intensity=False):
+def convert_range_image_to_cartesian(frame, range_images, range_image_top_pose, ri_index=0):
     """Convert range images from polar coordinates to Cartesian coordinates.
 
     Args:
@@ -101,13 +101,10 @@ def convert_range_image_to_cartesian(frame, range_images, range_image_top_pose, 
         range_image_second_return]}.
       range_image_top_pose: range image pixel pose for top lidar.
       ri_index: 0 for the first return, 1 for the second return.
-      keep_intensity: If true, keep the intensity from the polar range image
-        as the first features in the output range image.
 
     Returns:
-      dict of {laser_name, (H, W, D)} range images in Cartesian coordinates. D
-        will be 3 if keep_intensity is False (x, y, z) and 6 if
-        keep_intensity is True (intensity, x, y, z).
+      dict of {laser_name, (H, W, D)} range images in Cartesian coordinates.
+        5 fields are [intensity, elongation, x, y, z]
     """
     cartesian_range_images = {}
     frame_pose = np.reshape(np.array(frame.pose.transform), [4, 4])
@@ -153,19 +150,15 @@ def convert_range_image_to_cartesian(frame, range_images, range_image_top_pose, 
 
         range_image_cartesian = np.squeeze(range_image_cartesian, axis=0)
 
-        if keep_intensity:
-            # Note: we are not currently keeping range or elongation, which are available at this point.
-            # range_image_tensor columns are [range, intensity, elongation,x,y,z]
-            # If we want to keep intensity, concatenate them to be the
-            # initial dimensions of the returned Cartesian range image.
-            range_image_cartesian = np.concatenate([range_image_tensor[..., 1:2], range_image_cartesian], axis=-1)
+        # Note: we are not currently keeping range because it's repetitive with x,y,z., but it is available here
+        range_image_cartesian = np.concatenate([range_image_tensor[..., 1:3], range_image_cartesian], axis=-1)
 
         cartesian_range_images[c.name] = range_image_cartesian
 
     return cartesian_range_images
 
 
-def convert_range_image_to_point_cloud(frame, range_images, range_image_top_pose, ri_index=0, keep_intensity=False):
+def convert_range_image_to_point_cloud(frame, range_images, range_image_top_pose, ri_index=0):
     """Convert range images to point cloud.
     Note: camera projection points were removed from this function but were present in Waymo Open Dataset version.
 
@@ -175,20 +168,15 @@ def convert_range_image_to_point_cloud(frame, range_images, range_image_top_pose
         range_image_second_return]}.
       range_image_top_pose: range image pixel pose for top lidar.
       ri_index: 0 for the first return, 1 for the second return.
-      keep_intensity: If true, keep the features from the polar range image
-        (i.e. range, intensity, and elongation) as the first features in the
-        output range image.
 
     Returns:
-      points: {[N, 3]} list of 3d lidar points of length 5 (number of lidars).
-        (NOTE: Will be {[N, 6]} if keep_intensity is true.
+      points: {[N, 5]} list of 3d lidar points of length 5 (number of lidars).
+        5 fields are [intensity, elongation, x, y, z]
     """
     calibrations = sorted(frame.context.laser_calibrations, key=lambda c: c.name)
     points = []
 
-    cartesian_range_images = convert_range_image_to_cartesian(
-        frame, range_images, range_image_top_pose, ri_index, keep_intensity
-    )
+    cartesian_range_images = convert_range_image_to_cartesian(frame, range_images, range_image_top_pose, ri_index)
 
     for c in calibrations:
         range_image = range_images[c.name][ri_index]

--- a/paralleldomain/decoding/waymo_open_dataset/frame_utils.py
+++ b/paralleldomain/decoding/waymo_open_dataset/frame_utils.py
@@ -76,18 +76,9 @@ def parse_range_image_and_camera_projection(
             range_images, seg_labels, range_image_top_pose = parse_single_lidar_scanner(
                 laser=laser, range_images=range_images, seg_labels=seg_labels, range_image_top_pose=range_image_top_pose
             )
-    elif sensor_name in WAYMO_LIDAR_NAME_TO_INDEX:
-        # Only parse the sensor_name scanner
-        sensor_ix = (
-            WAYMO_LIDAR_NAME_TO_INDEX[sensor_name] - 1
-        )  # Sensor indices are indexed from 1 but the record.lasers is a list indexed from 0.
-        laser = record.lasers[sensor_ix]
-        range_images, seg_labels, range_image_top_pose = parse_single_lidar_scanner(
-            laser=laser, range_images=range_images, seg_labels=seg_labels, range_image_top_pose=range_image_top_pose
-        )
     else:
         raise KeyError(
-            f"sensor_name {sensor_name} not available in WAYMO_LIDAR_NAME_TO_INDEX: {WAYMO_LIDAR_NAME_TO_INDEX.keys()}"
+            f"For Waymo Open Dataset, all LiDAR sensors are combined. Single sensors are not currently supported."
         )
     return range_images, seg_labels, range_image_top_pose
 
@@ -150,7 +141,7 @@ def convert_range_image_to_cartesian(frame, range_images, range_image_top_pose, 
 
         range_image_cartesian = np.squeeze(range_image_cartesian, axis=0)
 
-        # Note: we are not currently keeping range because it's repetitive with x,y,z., but it is available here
+        # Note: not currently keeping range because it's repetitive with x,y,z., but it is available here
         range_image_cartesian = np.concatenate([range_image_cartesian, range_image_tensor[..., 1:3]], axis=-1)
 
         cartesian_range_images[c.name] = range_image_cartesian
@@ -177,7 +168,6 @@ def convert_range_image_to_point_cloud(frame, range_images, range_image_top_pose
     points = []
 
     cartesian_range_images = convert_range_image_to_cartesian(frame, range_images, range_image_top_pose, ri_index)
-
     for c in calibrations:
         range_image = range_images[c.name][ri_index]
         range_image_tensor = np.asarray(range_image.data).reshape(range_image.shape.dims)

--- a/paralleldomain/decoding/waymo_open_dataset/frame_utils.py
+++ b/paralleldomain/decoding/waymo_open_dataset/frame_utils.py
@@ -1,0 +1,446 @@
+import zlib
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+# from waymo_open_dataset import dataset_pb2
+from paralleldomain.decoding.waymo_open_dataset.protos import dataset_pb2
+
+RangeImages = Dict["dataset_pb2.LaserName.Name", List[dataset_pb2.MatrixFloat]]
+CameraProjections = Dict["dataset_pb2.LaserName.Name", List[dataset_pb2.MatrixInt32]]
+SegmentationLabels = Dict["dataset_pb2.LaserName.Name", List[dataset_pb2.MatrixInt32]]
+ParsedFrame = Tuple[RangeImages, CameraProjections, SegmentationLabels, Optional[dataset_pb2.MatrixFloat]]
+
+"""
+These functions were brought in from waymo_open_datset frame_utils.py, range_utils.py, and transform_utils.py
+The only adjustment was the removal of the dependency on tensorflow, replaced with numpy functions.
+"""
+
+
+def parse_range_image_and_camera_projection(frame: dataset_pb2.Frame) -> ParsedFrame:
+    """Parse range images and camera projections given a frame.
+
+    Args:
+      frame: open dataset frame proto
+
+    Returns:
+      range_images: A dict of {laser_name,
+        [range_image_first_return, range_image_second_return]}.
+      camera_projections: A dict of {laser_name,
+        [camera_projection_from_first_return,
+        camera_projection_from_second_return]}.
+      seg_labels: segmentation labels, a dict of {laser_name,
+        [seg_label_first_return, seg_label_second_return]}
+      range_image_top_pose: range image pixel pose for top lidar.
+    """
+    range_images = {}
+    camera_projections = {}
+    seg_labels = {}
+    range_image_top_pose = None
+    for laser in frame.lasers:
+        if len(laser.ri_return1.range_image_compressed) > 0:  # pylint: disable=g-explicit-length-test
+            range_image_str_tensor = zlib.decompress(laser.ri_return1.range_image_compressed)
+            ri = dataset_pb2.MatrixFloat()
+            ri.ParseFromString(bytearray(range_image_str_tensor))
+            range_images[laser.name] = [ri]
+
+            if laser.name == dataset_pb2.LaserName.TOP:
+                range_image_top_pose_str_tensor = zlib.decompress(laser.ri_return1.range_image_pose_compressed)
+                range_image_top_pose = dataset_pb2.MatrixFloat()
+                range_image_top_pose.ParseFromString(bytearray(range_image_top_pose_str_tensor))
+
+            camera_projection_str_tensor = zlib.decompress(laser.ri_return1.camera_projection_compressed)
+            cp = dataset_pb2.MatrixInt32()
+            cp.ParseFromString(bytearray(camera_projection_str_tensor))
+            camera_projections[laser.name] = [cp]
+
+            if len(laser.ri_return1.segmentation_label_compressed) > 0:  # pylint: disable=g-explicit-length-test
+                seg_label_str_tensor = zlib.decompress(laser.ri_return1.segmentation_label_compressed)
+                seg_label = dataset_pb2.MatrixInt32()
+                seg_label.ParseFromString(bytearray(seg_label_str_tensor))
+                seg_labels[laser.name] = [seg_label]
+        if len(laser.ri_return2.range_image_compressed) > 0:  # pylint: disable=g-explicit-length-test
+            range_image_str_tensor = zlib.decompress(laser.ri_return2.range_image_compressed)
+            ri = dataset_pb2.MatrixFloat()
+            ri.ParseFromString(bytearray(range_image_str_tensor))
+            range_images[laser.name].append(ri)
+
+            camera_projection_str_tensor = zlib.decompress(laser.ri_return2.camera_projection_compressed)
+            cp = dataset_pb2.MatrixInt32()
+            cp.ParseFromString(bytearray(camera_projection_str_tensor))
+            camera_projections[laser.name].append(cp)
+
+            if len(laser.ri_return2.segmentation_label_compressed) > 0:  # pylint: disable=g-explicit-length-test
+                seg_label_str_tensor = zlib.decompress(laser.ri_return2.segmentation_label_compressed)
+                seg_label = dataset_pb2.MatrixInt32()
+                seg_label.ParseFromString(bytearray(seg_label_str_tensor))
+                seg_labels[laser.name].append(seg_label)
+    return range_images, camera_projections, seg_labels, range_image_top_pose
+
+
+def convert_range_image_to_cartesian(frame, range_images, range_image_top_pose, ri_index=0, keep_polar_features=False):
+    """Convert range images from polar coordinates to Cartesian coordinates.
+
+    Args:
+      frame: open dataset frame
+      range_images: A dict of {laser_name, [range_image_first_return,
+        range_image_second_return]}.
+      range_image_top_pose: range image pixel pose for top lidar.
+      ri_index: 0 for the first return, 1 for the second return.
+      keep_polar_features: If true, keep the features from the polar range image
+        (i.e. range, intensity, and elongation) as the first features in the
+        output range image.
+
+    Returns:
+      dict of {laser_name, (H, W, D)} range images in Cartesian coordinates. D
+        will be 3 if keep_polar_features is False (x, y, z) and 6 if
+        keep_polar_features is True (range, intensity, elongation, x, y, z).
+    """
+    cartesian_range_images = {}
+    frame_pose = np.reshape(np.array(frame.pose.transform), [4, 4])
+
+    # [H, W, 6]
+    range_image_top_pose_tensor = np.asarray(range_image_top_pose.data).reshape(range_image_top_pose.shape.dims)
+
+    # [H, W, 3, 3]
+    range_image_top_pose_tensor_rotation = get_rotation_matrix(
+        range_image_top_pose_tensor[..., 0], range_image_top_pose_tensor[..., 1], range_image_top_pose_tensor[..., 2]
+    )
+    range_image_top_pose_tensor_translation = range_image_top_pose_tensor[..., 3:]
+    range_image_top_pose_tensor = get_transform(
+        range_image_top_pose_tensor_rotation, range_image_top_pose_tensor_translation
+    )
+
+    for c in frame.context.laser_calibrations:
+        range_image = range_images[c.name][ri_index]
+        if len(c.beam_inclinations) == 0:  # pylint: disable=g-explicit-length-test
+            beam_inclinations = compute_inclination(
+                np.array([c.beam_inclination_min, c.beam_inclination_max]), height=range_image.shape.dims[0]
+            )
+        else:
+            beam_inclinations = np.array(c.beam_inclinations)
+
+        beam_inclinations = np.flip(beam_inclinations, axis=-1)
+        extrinsic = np.reshape(np.array(c.extrinsic.transform), [4, 4])
+
+        range_image_tensor = np.asarray(range_image.data).reshape(range_image.shape.dims)
+        pixel_pose_local = None
+        frame_pose_local = None
+        if c.name == dataset_pb2.LaserName.TOP:
+            pixel_pose_local = range_image_top_pose_tensor
+            pixel_pose_local = np.expand_dims(pixel_pose_local, axis=0)
+            frame_pose_local = np.expand_dims(frame_pose, axis=0)
+        range_image_cartesian = extract_point_cloud_from_range_image(
+            np.expand_dims(range_image_tensor[..., 0], axis=0),
+            np.expand_dims(extrinsic, axis=0),
+            np.expand_dims(beam_inclinations, axis=0),
+            pixel_pose=pixel_pose_local,
+            frame_pose=frame_pose_local,
+        )
+
+        range_image_cartesian = np.squeeze(range_image_cartesian, axis=0)
+
+        if keep_polar_features:
+            # If we want to keep the polar coordinate features of range, intensity,
+            # and elongation, concatenate them to be the initial dimensions of the
+            # returned Cartesian range image.
+            range_image_cartesian = np.concat([range_image_tensor[..., 0:3], range_image_cartesian], axis=-1)
+
+        cartesian_range_images[c.name] = range_image_cartesian
+
+    return cartesian_range_images
+
+
+def convert_range_image_to_point_cloud(
+    frame, range_images, camera_projections, range_image_top_pose, ri_index=0, keep_polar_features=False
+):
+    """Convert range images to point cloud.
+
+    Args:
+      frame: open dataset frame
+      range_images: A dict of {laser_name, [range_image_first_return,
+        range_image_second_return]}.
+      camera_projections: A dict of {laser_name,
+        [camera_projection_from_first_return,
+        camera_projection_from_second_return]}.
+      range_image_top_pose: range image pixel pose for top lidar.
+      ri_index: 0 for the first return, 1 for the second return.
+      keep_polar_features: If true, keep the features from the polar range image
+        (i.e. range, intensity, and elongation) as the first features in the
+        output range image.
+
+    Returns:
+      points: {[N, 3]} list of 3d lidar points of length 5 (number of lidars).
+        (NOTE: Will be {[N, 6]} if keep_polar_features is true.
+      cp_points: {[N, 6]} list of camera projections of length 5
+        (number of lidars).
+    """
+    calibrations = sorted(frame.context.laser_calibrations, key=lambda c: c.name)
+    points = []
+    cp_points = []
+
+    cartesian_range_images = convert_range_image_to_cartesian(
+        frame, range_images, range_image_top_pose, ri_index, keep_polar_features
+    )
+
+    for c in calibrations:
+        range_image = range_images[c.name][ri_index]
+        range_image_tensor = np.asarray(range_image.data).reshape(range_image.shape.dims)
+        range_image_mask = range_image_tensor[..., 0] > 0
+
+        range_image_cartesian = cartesian_range_images[c.name]
+        points_tensor = range_image_cartesian[range_image_mask]
+
+        cp = camera_projections[c.name][ri_index]
+        cp_tensor = np.asarray(cp.data).reshape(cp.shape.dims)
+        cp_points_tensor = cp_tensor[range_image_mask]
+        points.append(points_tensor)
+        cp_points.append(cp_points_tensor)
+
+    return points, cp_points
+
+
+def get_rotation_matrix(roll, pitch, yaw, name=None):
+    """Gets a rotation matrix given roll, pitch, yaw.
+
+    roll-pitch-yaw is z-y'-x'' intrinsic rotation which means we need to apply
+    x(roll) rotation first, then y(pitch) rotation, then z(yaw) rotation.
+
+    https://en.wikipedia.org/wiki/Euler_angles
+    http://planning.cs.uiuc.edu/node102.html
+
+    Args:
+      roll : x-rotation in radians.
+      pitch: y-rotation in radians. The shape must be the same as roll.
+      yaw: z-rotation in radians. The shape must be the same as roll.
+      name: the op name.
+
+    Returns:
+      A rotation tensor with the same data type of the input. Its shape is
+        [input_shape_of_yaw, 3 ,3].
+    """
+
+    cos_roll = np.cos(roll)
+    sin_roll = np.sin(roll)
+    cos_yaw = np.cos(yaw)
+    sin_yaw = np.sin(yaw)
+    cos_pitch = np.cos(pitch)
+    sin_pitch = np.sin(pitch)
+
+    ones = np.ones_like(yaw)
+    zeros = np.zeros_like(yaw)
+
+    r_roll = np.stack(
+        [
+            np.stack([ones, zeros, zeros], axis=-1),
+            np.stack([zeros, cos_roll, -1.0 * sin_roll], axis=-1),
+            np.stack([zeros, sin_roll, cos_roll], axis=-1),
+        ],
+        axis=-2,
+    )
+    r_pitch = np.stack(
+        [
+            np.stack([cos_pitch, zeros, sin_pitch], axis=-1),
+            np.stack([zeros, ones, zeros], axis=-1),
+            np.stack([-1.0 * sin_pitch, zeros, cos_pitch], axis=-1),
+        ],
+        axis=-2,
+    )
+    r_yaw = np.stack(
+        [
+            np.stack([cos_yaw, -1.0 * sin_yaw, zeros], axis=-1),
+            np.stack([sin_yaw, cos_yaw, zeros], axis=-1),
+            np.stack([zeros, zeros, ones], axis=-1),
+        ],
+        axis=-2,
+    )
+
+    return np.matmul(r_yaw, np.matmul(r_pitch, r_roll))
+
+
+def get_transform(rotation, translation):
+    """Combines NxN rotation and Nx1 translation to (N+1)x(N+1) transform.
+
+    Args:
+      rotation: [..., N, N] rotation tensor.
+      translation: [..., N] translation tensor. This must have the same type as
+        rotation.
+
+    Returns:
+      transform: [..., (N+1), (N+1)] transform tensor. This has the same type as
+        rotation.
+    """
+    # [..., N, 1]
+    translation_n_1 = translation[..., np.newaxis]
+    # [..., N, N+1]
+    transform = np.concatenate([rotation, translation_n_1], axis=-1)
+    # [..., N]
+    last_row = np.zeros_like(translation)
+    # [..., N+1]
+    last_row = np.concatenate([last_row, np.ones_like(last_row[..., 0:1])], axis=-1)
+    # [..., N+1, N+1]
+    transform = np.concatenate([transform, last_row[..., np.newaxis, :]], axis=-2)
+    return transform
+
+
+def compute_range_image_polar(range_image, extrinsic, inclination, dtype=np.float32, scope=None):
+    """Computes range image polar coordinates.
+
+    Args:
+      range_image: [B, H, W] tensor. Lidar range images.
+      extrinsic: [B, 4, 4] tensor. Lidar extrinsic.
+      inclination: [B, H] tensor. Inclination for each row of the range image.
+        0-th entry corresponds to the 0-th row of the range image.
+      dtype: float type to use internally. This is needed as extrinsic and
+        inclination sometimes have higher resolution than range_image.
+      scope: the name scope.
+
+    Returns:
+      range_image_polar: [B, H, W, 3] polar coordinates.
+    """
+    # pylint: disable=unbalanced-tuple-unpacking
+    _, height, width = range_image.shape
+    range_image_dtype = range_image.dtype
+    range_image = range_image.astype(dtype)
+    extrinsic = extrinsic.astype(dtype)
+    inclination = inclination.astype(dtype)
+
+    # [B].
+    az_correction = np.arctan2(extrinsic[..., 1, 0], extrinsic[..., 0, 0])
+    # [W].
+    ratios = (np.arange(width, 0, -1).astype(dtype) - 0.5) / np.array(width).astype(dtype)
+    # [B, W].
+    azimuth = (ratios * 2.0 - 1.0) * np.pi - np.expand_dims(az_correction, -1)
+
+    # [B, H, W]
+    azimuth_tile = np.tile(azimuth[:, np.newaxis, :], [1, height, 1])
+    # [B, H, W]
+    inclination_tile = np.tile(inclination[:, :, np.newaxis], [1, 1, width])
+    range_image_polar = np.stack([azimuth_tile, inclination_tile, range_image], axis=-1)
+    return range_image_polar.astype(range_image_dtype)
+
+
+def compute_range_image_cartesian(
+    range_image_polar, extrinsic, pixel_pose=None, frame_pose=None, dtype=np.float32, scope=None
+):
+    """Computes range image cartesian coordinates from polar ones.
+
+    Args:
+      range_image_polar: [B, H, W, 3] float tensor. Lidar range image in polar
+        coordinate in sensor frame.
+      extrinsic: [B, 4, 4] float tensor. Lidar extrinsic.
+      pixel_pose: [B, H, W, 4, 4] float tensor. If not None, it sets pose for each
+        range image pixel.
+      frame_pose: [B, 4, 4] float tensor. This must be set when pixel_pose is set.
+        It decides the vehicle frame at which the cartesian points are computed.
+      dtype: float type to use internally. This is needed as extrinsic and
+        inclination sometimes have higher resolution than range_image.
+      scope: the name scope.
+
+    Returns:
+      range_image_cartesian: [B, H, W, 3] cartesian coordinates.
+    """
+    range_image_polar_dtype = range_image_polar.dtype
+    range_image_polar = range_image_polar.astype(dtype)
+    extrinsic = extrinsic.astype(dtype)
+    if pixel_pose is not None:
+        pixel_pose = pixel_pose.astype(dtype)
+    if frame_pose is not None:
+        frame_pose = frame_pose.astype(dtype)
+
+    azimuth, inclination, range_image_range = np.moveaxis(range_image_polar, -1, 0)
+
+    cos_azimuth = np.cos(azimuth)
+    sin_azimuth = np.sin(azimuth)
+    cos_incl = np.cos(inclination)
+    sin_incl = np.sin(inclination)
+
+    # [B, H, W].
+    x = cos_azimuth * cos_incl * range_image_range
+    y = sin_azimuth * cos_incl * range_image_range
+    z = sin_incl * range_image_range
+
+    # [B, H, W, 3]
+    range_image_points = np.stack([x, y, z], -1)
+    # [B, 3, 3]
+    rotation = extrinsic[..., 0:3, 0:3]
+    # translation [B, 1, 3]
+    translation = np.expand_dims(np.expand_dims(extrinsic[..., 0:3, 3], 1), 1)
+
+    # To vehicle frame.
+    # [B, H, W, 3]
+    range_image_points = np.einsum("bkr,bijr->bijk", rotation, range_image_points) + translation
+    if pixel_pose is not None:
+        # To global frame.
+        # [B, H, W, 3, 3]
+        pixel_pose_rotation = pixel_pose[..., 0:3, 0:3]
+        # [B, H, W, 3]
+        pixel_pose_translation = pixel_pose[..., 0:3, 3]
+        # [B, H, W, 3]
+        range_image_points = (
+            np.einsum("bhwij,bhwj->bhwi", pixel_pose_rotation, range_image_points) + pixel_pose_translation
+        )
+        if frame_pose is None:
+            raise ValueError("frame_pose must be set when pixel_pose is set.")
+        # To vehicle frame corresponding to the given frame_pose
+        # [B, 4, 4]
+        world_to_vehicle = np.linalg.inv(frame_pose)
+        world_to_vehicle_rotation = world_to_vehicle[:, 0:3, 0:3]
+        world_to_vehicle_translation = world_to_vehicle[:, 0:3, 3]
+        # [B, H, W, 3]
+        range_image_points = (
+            np.einsum("bij,bhwj->bhwi", world_to_vehicle_rotation, range_image_points)
+            + world_to_vehicle_translation[:, np.newaxis, np.newaxis, :]
+        )
+
+    range_image_points = range_image_points.astype(range_image_polar_dtype)
+    return range_image_points
+
+
+def extract_point_cloud_from_range_image(
+    range_image, extrinsic, inclination, pixel_pose=None, frame_pose=None, dtype=np.float32, scope=None
+):
+    """Extracts point cloud from range image.
+
+    Args:
+      range_image: [B, H, W] tensor. Lidar range images.
+      extrinsic: [B, 4, 4] tensor. Lidar extrinsic.
+      inclination: [B, H] tensor. Inclination for each row of the range image.
+        0-th entry corresponds to the 0-th row of the range image.
+      pixel_pose: [B, H, W, 4, 4] tensor. If not None, it sets pose for each range
+        image pixel.
+      frame_pose: [B, 4, 4] tensor. This must be set when pixel_pose is set. It
+        decides the vehicle frame at which the cartesian points are computed.
+      dtype: float type to use internally. This is needed as extrinsic and
+        inclination sometimes have higher resolution than range_image.
+      scope: the name scope.
+
+    Returns:
+      range_image_cartesian: [B, H, W, 3] with {x, y, z} as inner dims in vehicle
+      frame.
+    """
+    range_image_polar = compute_range_image_polar(range_image, extrinsic, inclination, dtype=dtype)
+    range_image_cartesian = compute_range_image_cartesian(
+        range_image_polar, extrinsic, pixel_pose=pixel_pose, frame_pose=frame_pose, dtype=dtype
+    )
+    return range_image_cartesian
+
+
+def compute_inclination(inclination_range, height, scope=None):
+    """Computes uniform inclination range based the given range and height.
+
+    Args:
+      inclination_range: [..., 2] tensor. Inner dims are [min inclination, max
+        inclination].
+      height: an integer indicates height of the range image.
+      scope: the name scope.
+
+    Returns:
+      inclination: [..., height] tensor. Inclinations computed.
+    """
+    height = np.array(height)
+    diff = inclination_range[..., 1] - inclination_range[..., 0]
+    inclination = (0.5 + np.arange(0, height).astype(inclination_range.dtype)) / height.astype(
+        inclination_range.dtype
+    ) * np.expand_dims(diff, axis=-1) + inclination_range[..., 0:1]
+    return inclination

--- a/paralleldomain/decoding/waymo_open_dataset/sensor_decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/sensor_decoder.py
@@ -73,9 +73,11 @@ class WaymoOpenDatasetLidarSensorDecoder(LidarSensorDecoder[datetime]):
         settings: DecoderSettings,
         use_precalculated_maps: bool,
         split_name: str,
+        include_second_returns: bool,
     ):
         super().__init__(dataset_name=dataset_name, scene_name=scene_name, settings=settings)
         self.split_name = split_name
+        self.include_second_returns = include_second_returns
         self.use_precalculated_maps = use_precalculated_maps
         self._dataset_path = dataset_path
 
@@ -106,4 +108,5 @@ class WaymoOpenDatasetLidarSensorDecoder(LidarSensorDecoder[datetime]):
             settings=self.settings,
             use_precalculated_maps=self.use_precalculated_maps,
             split_name=self.split_name,
+            include_second_returns=self.include_second_returns,
         )

--- a/paralleldomain/decoding/waymo_open_dataset/sensor_decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/sensor_decoder.py
@@ -6,7 +6,7 @@ from paralleldomain.decoding.common import DecoderSettings
 from paralleldomain.decoding.sensor_decoder import CameraSensorDecoder
 from paralleldomain.decoding.sensor_frame_decoder import CameraSensorFrameDecoder
 from paralleldomain.decoding.waymo_open_dataset.common import (
-    get_cached_pre_calcualted_scene_to_frame_info,
+    get_cached_pre_calculated_scene_to_frame_info,
     get_record_iterator,
 )
 from paralleldomain.decoding.waymo_open_dataset.sensor_frame_decoder import WaymoOpenDatasetCameraSensorFrameDecoder
@@ -33,7 +33,7 @@ class WaymoOpenDatasetCameraSensorDecoder(CameraSensorDecoder[datetime]):
 
     def _decode_frame_id_set(self, sensor_name: SensorName) -> Set[FrameId]:
         if self.use_precalculated_maps and self.split_name in ["training", "validation"]:
-            id_map = get_cached_pre_calcualted_scene_to_frame_info(
+            id_map = get_cached_pre_calculated_scene_to_frame_info(
                 lazy_load_cache=self.lazy_load_cache, dataset_name=self.dataset_name, split_name=self.split_name
             )
             if self.scene_name in id_map:

--- a/paralleldomain/decoding/waymo_open_dataset/sensor_decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/sensor_decoder.py
@@ -3,15 +3,18 @@ from functools import lru_cache
 from typing import List, Optional, Set
 
 from paralleldomain.decoding.common import DecoderSettings
-from paralleldomain.decoding.sensor_decoder import CameraSensorDecoder
-from paralleldomain.decoding.sensor_frame_decoder import CameraSensorFrameDecoder
+from paralleldomain.decoding.sensor_decoder import CameraSensorDecoder, LidarSensorDecoder
+from paralleldomain.decoding.sensor_frame_decoder import CameraSensorFrameDecoder, LidarSensorFrameDecoder
 from paralleldomain.decoding.waymo_open_dataset.common import (
     get_cached_pre_calculated_scene_to_frame_info,
     get_record_iterator,
 )
-from paralleldomain.decoding.waymo_open_dataset.sensor_frame_decoder import WaymoOpenDatasetCameraSensorFrameDecoder
+from paralleldomain.decoding.waymo_open_dataset.sensor_frame_decoder import (
+    WaymoOpenDatasetCameraSensorFrameDecoder,
+    WaymoOpenDatasetLidarSensorFrameDecoder,
+)
 from paralleldomain.model.class_mapping import ClassDetail
-from paralleldomain.model.sensor import CameraSensorFrame
+from paralleldomain.model.sensor import CameraSensorFrame, LidarSensorFrame
 from paralleldomain.model.type_aliases import FrameId, SceneName, SensorName
 from paralleldomain.utilities.any_path import AnyPath
 
@@ -52,6 +55,51 @@ class WaymoOpenDatasetCameraSensorDecoder(CameraSensorDecoder[datetime]):
 
     def _create_camera_sensor_frame_decoder(self) -> CameraSensorFrameDecoder[None]:
         return WaymoOpenDatasetCameraSensorFrameDecoder(
+            dataset_name=self.dataset_name,
+            scene_name=self.scene_name,
+            dataset_path=self._dataset_path,
+            settings=self.settings,
+            use_precalculated_maps=self.use_precalculated_maps,
+            split_name=self.split_name,
+        )
+
+
+class WaymoOpenDatasetLidarSensorDecoder(LidarSensorDecoder[datetime]):
+    def __init__(
+        self,
+        dataset_name: str,
+        scene_name: SceneName,
+        dataset_path: AnyPath,
+        settings: DecoderSettings,
+        use_precalculated_maps: bool,
+        split_name: str,
+    ):
+        super().__init__(dataset_name=dataset_name, scene_name=scene_name, settings=settings)
+        self.split_name = split_name
+        self.use_precalculated_maps = use_precalculated_maps
+        self._dataset_path = dataset_path
+
+    def _decode_frame_id_set(self, sensor_name: SensorName) -> Set[FrameId]:
+        if self.use_precalculated_maps and self.split_name in ["training", "validation"]:
+            id_map = get_cached_pre_calculated_scene_to_frame_info(
+                lazy_load_cache=self.lazy_load_cache, dataset_name=self.dataset_name, split_name=self.split_name
+            )
+            if self.scene_name in id_map:
+                return [elem["frame_id"] for elem in id_map[self.scene_name]]
+
+        record = self._dataset_path / self.scene_name
+        frame_ids = list()
+        for _, frame_id in get_record_iterator(record_path=record, read_frame=False):
+            frame_ids.append(frame_id)
+        return frame_ids
+
+    def _decode_lidar_sensor_frame(
+        self, decoder: LidarSensorFrameDecoder[datetime], frame_id: FrameId, lidar_name: SensorName
+    ) -> LidarSensorFrame[None]:
+        return LidarSensorFrame[None](sensor_name=lidar_name, frame_id=frame_id, decoder=decoder)
+
+    def _create_lidar_sensor_frame_decoder(self) -> LidarSensorFrameDecoder[None]:
+        return WaymoOpenDatasetLidarSensorFrameDecoder(
             dataset_name=self.dataset_name,
             scene_name=self.scene_name,
             dataset_path=self._dataset_path,

--- a/paralleldomain/decoding/waymo_open_dataset/sensor_frame_decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/sensor_frame_decoder.py
@@ -12,7 +12,7 @@ from paralleldomain.decoding.waymo_open_dataset.common import (
     WAYMO_CAMERA_NAME_TO_INDEX,
     WaymoFileAccessMixin,
     decode_class_maps,
-    get_cached_pre_calcualted_scene_to_has_segmentation,
+    get_cached_pre_calculated_scene_to_has_segmentation,
 )
 from paralleldomain.model.annotation import (
     AnnotationType,
@@ -74,7 +74,7 @@ class WaymoOpenDatasetCameraSensorFrameDecoder(CameraSensorFrameDecoder[datetime
         self, sensor_name: SensorName, frame_id: FrameId
     ) -> Dict[AnnotationType, AnnotationIdentifier]:
         if self.use_precalculated_maps and self.split_name == "training":
-            has_segmentation = get_cached_pre_calcualted_scene_to_has_segmentation(
+            has_segmentation = get_cached_pre_calculated_scene_to_has_segmentation(
                 lazy_load_cache=self.lazy_load_cache,
                 dataset_name=self.dataset_name,
                 scene_name=self.scene_name,

--- a/paralleldomain/decoding/waymo_open_dataset/sensor_frame_decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/sensor_frame_decoder.py
@@ -272,7 +272,7 @@ class WaymoOpenDatasetLidarSensorFrameDecoder(LidarSensorFrameDecoder[datetime],
 
     def _decode_point_cloud_intensity(self, sensor_name: SensorName, frame_id: FrameId) -> Optional[np.ndarray]:
         data = self._decode_point_cloud_data(sensor_name=sensor_name, frame_id=frame_id)
-        return data[:, 3]
+        return data[:, 3].reshape(-1, 1)
 
     def _decode_point_cloud_timestamp(self, sensor_name: SensorName, frame_id: FrameId) -> Optional[np.ndarray]:
         return -1 * np.ones(self._decode_point_cloud_size(sensor_name=sensor_name, frame_id=frame_id))

--- a/paralleldomain/decoding/waymo_open_dataset/sensor_frame_decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/sensor_frame_decoder.py
@@ -263,7 +263,7 @@ class WaymoOpenDatasetLidarSensorFrameDecoder(LidarSensorFrameDecoder[datetime],
 
     def _decode_point_cloud_xyz(self, sensor_name: SensorName, frame_id: FrameId) -> Optional[np.ndarray]:
         data = self._decode_point_cloud_data(sensor_name=sensor_name, frame_id=frame_id)
-        return data[:, :3]
+        return data[:, 2:]
 
     def _decode_point_cloud_rgb(self, sensor_name: SensorName, frame_id: FrameId) -> Optional[np.ndarray]:
         """
@@ -273,17 +273,14 @@ class WaymoOpenDatasetLidarSensorFrameDecoder(LidarSensorFrameDecoder[datetime],
         return np.zeros([cloud_size, 3])
 
     def _decode_point_cloud_intensity(self, sensor_name: SensorName, frame_id: FrameId) -> Optional[np.ndarray]:
-        # data = self._decode_point_cloud_data(sensor_name=sensor_name, frame_id=frame_id)
-        # return data[:, 3].reshape(-1, 1)
-        raise NotImplementedError("Currently not decoding intensity for Waymo Open Dataset.")
+        data = self._decode_point_cloud_data(sensor_name=sensor_name, frame_id=frame_id)
+        return data[:, 1]
 
     def _decode_point_cloud_timestamp(self, sensor_name: SensorName, frame_id: FrameId) -> Optional[np.ndarray]:
-        # return -1 * np.ones(self._decode_point_cloud_size(sensor_name=sensor_name, frame_id=frame_id))
-        raise NotImplementedError("Currently not decoding timestamps for Waymo Open Dataset.")
+        return -1 * np.ones(self._decode_point_cloud_size(sensor_name=sensor_name, frame_id=frame_id))
 
-    # TODO: Replace with decode_point_cloud_laser_index
     def _decode_point_cloud_ring_index(self, sensor_name: SensorName, frame_id: FrameId) -> Optional[np.ndarray]:
-        raise NotImplementedError("No ring data for Waymo Open Dataset.")
+        return -1 * np.ones(self._decode_point_cloud_size(sensor_name=sensor_name, frame_id=frame_id))
 
     def _decode_point_cloud_ray_type(self, sensor_name: SensorName, frame_id: FrameId) -> Optional[np.ndarray]:
         return None

--- a/paralleldomain/decoding/waymo_open_dataset/sensor_frame_decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/sensor_frame_decoder.py
@@ -240,8 +240,12 @@ class WaymoOpenDatasetLidarSensorFrameDecoder(LidarSensorFrameDecoder[datetime],
         )
 
         # Point Cloud Conversion and Viz
-        points = convert_range_image_to_point_cloud(record, range_images, range_image_top_pose)
-        points_ri2 = convert_range_image_to_point_cloud(record, range_images, range_image_top_pose, ri_index=1)
+        points = convert_range_image_to_point_cloud(
+            record, range_images, range_image_top_pose, keep_polar_features=True
+        )
+        points_ri2 = convert_range_image_to_point_cloud(
+            record, range_images, range_image_top_pose, ri_index=1, keep_polar_features=True
+        )
         # 3d points in vehicle frame.
         points_all = np.concatenate(points, axis=0)
         points_all_ri2 = np.concatenate(points_ri2, axis=0)

--- a/paralleldomain/decoding/waymo_open_dataset/sensor_frame_decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/sensor_frame_decoder.py
@@ -87,16 +87,16 @@ class WaymoOpenDatasetSensorFrameDecoder(SensorFrameDecoder[datetime], WaymoFile
                 )
         else:
             record = self.get_record_at(frame_id=frame_id)
-
-            cam_index = WAYMO_CAMERA_NAME_TO_INDEX[sensor_name] - 1
-            cam_data = record.images[cam_index]
-            if cam_data.camera_segmentation_label.panoptic_label:
-                available_annotations.update(
-                    {
-                        AnnotationTypes.SemanticSegmentation2D: f"{frame_id}",
-                        AnnotationTypes.InstanceSegmentation2D: f"{frame_id}",
-                    }
-                )
+            if isinstance(self, WaymoOpenDatasetCameraSensorFrameDecoder):
+                cam_index = WAYMO_CAMERA_NAME_TO_INDEX[sensor_name] - 1
+                cam_data = record.images[cam_index]
+                if cam_data.camera_segmentation_label.panoptic_label:
+                    available_annotations.update(
+                        {
+                            AnnotationTypes.SemanticSegmentation2D: f"{frame_id}",
+                            AnnotationTypes.InstanceSegmentation2D: f"{frame_id}",
+                        }
+                    )
         return available_annotations
 
     def _decode_metadata(self, sensor_name: SensorName, frame_id: FrameId) -> Dict[str, Any]:
@@ -156,7 +156,6 @@ class WaymoOpenDatasetSensorFrameDecoder(SensorFrameDecoder[datetime], WaymoFile
         _, instance_label = np.divmod(panoptic_label, panoptic_label_divisor)
         return np.expand_dims(instance_label, -1).astype(int)
 
-    # TODO: Double check boxes in visualizer
     def _decode_bounding_boxes_3d(self, sensor_name: SensorName, frame_id: FrameId) -> List[BoundingBox3D]:
         boxes = list()
         record = self.get_record_at(frame_id=frame_id)

--- a/paralleldomain/decoding/waymo_open_dataset/sensor_frame_decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/sensor_frame_decoder.py
@@ -229,7 +229,7 @@ class WaymoOpenDatasetLidarSensorFrameDecoder(LidarSensorFrameDecoder[datetime],
         self, frame_id: FrameId, sensor_name: SensorName = WAYMO_USE_ALL_LIDAR_NAME
     ) -> Optional[np.ndarray]:
         """
-        Waymo record.lasers schema is [intensity, elongation, x, y, z]
+        Waymo record.lasers schema is [x, y, z, intensity, elongation]
         Elongation :
         Lidar elongation refers to the elongation of the pulse beyond its nominal width.
         Returns with long pulse elongation, for example, indicate that the laser reflection
@@ -261,7 +261,7 @@ class WaymoOpenDatasetLidarSensorFrameDecoder(LidarSensorFrameDecoder[datetime],
 
     def _decode_point_cloud_xyz(self, sensor_name: SensorName, frame_id: FrameId) -> Optional[np.ndarray]:
         data = self._decode_point_cloud_data(sensor_name=sensor_name, frame_id=frame_id)
-        return data[:, 2:]
+        return data[:, :3]
 
     def _decode_point_cloud_rgb(self, sensor_name: SensorName, frame_id: FrameId) -> Optional[np.ndarray]:
         """
@@ -272,7 +272,7 @@ class WaymoOpenDatasetLidarSensorFrameDecoder(LidarSensorFrameDecoder[datetime],
 
     def _decode_point_cloud_intensity(self, sensor_name: SensorName, frame_id: FrameId) -> Optional[np.ndarray]:
         data = self._decode_point_cloud_data(sensor_name=sensor_name, frame_id=frame_id)
-        return data[:, 1]
+        return data[:, 3]
 
     def _decode_point_cloud_timestamp(self, sensor_name: SensorName, frame_id: FrameId) -> Optional[np.ndarray]:
         return -1 * np.ones(self._decode_point_cloud_size(sensor_name=sensor_name, frame_id=frame_id))

--- a/paralleldomain/decoding/waymo_open_dataset/sensor_frame_decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/sensor_frame_decoder.py
@@ -16,6 +16,7 @@ from paralleldomain.decoding.sensor_frame_decoder import (
 )
 from paralleldomain.decoding.waymo_open_dataset.common import (
     WAYMO_CAMERA_NAME_TO_INDEX,
+    WAYMO_USE_ALL_LIDAR_NAME,
     WaymoFileAccessMixin,
     decode_class_maps,
     get_cached_pre_calculated_scene_to_has_segmentation,
@@ -226,13 +227,17 @@ class WaymoOpenDatasetLidarSensorFrameDecoder(LidarSensorFrameDecoder[datetime],
     # TODO: Add include_second_returns boolean
     # TODO: Add intensity
     # TODO: Add ring index
-    def _decode_point_cloud_data(self, frame_id: FrameId, sensor_name: SensorName = "lidar") -> Optional[np.ndarray]:
+    def _decode_point_cloud_data(
+        self, frame_id: FrameId, sensor_name: SensorName = WAYMO_USE_ALL_LIDAR_NAME
+    ) -> Optional[np.ndarray]:
         """
         Waymo record.lasers schema is [range, intensity, and elongation, x, y, z]
         """
         record = self.get_record_at(frame_id=frame_id)
         # Range image to point cloud processing
-        (range_images, _, range_image_top_pose) = parse_range_image_and_camera_projection(record)
+        (range_images, _, range_image_top_pose) = parse_range_image_and_camera_projection(
+            record=record, sensor_name=sensor_name
+        )
 
         # Point Cloud Conversion and Viz
         points = convert_range_image_to_point_cloud(record, range_images, range_image_top_pose)

--- a/paralleldomain/decoding/waymo_open_dataset/sensor_frame_decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/sensor_frame_decoder.py
@@ -231,7 +231,12 @@ class WaymoOpenDatasetLidarSensorFrameDecoder(LidarSensorFrameDecoder[datetime],
         self, frame_id: FrameId, sensor_name: SensorName = WAYMO_USE_ALL_LIDAR_NAME
     ) -> Optional[np.ndarray]:
         """
-        Waymo record.lasers schema is [range, intensity, and elongation, x, y, z]
+        Waymo record.lasers schema is [intensity, elongation, x, y, z]
+        Elongation :
+        Lidar elongation refers to the elongation of the pulse beyond its nominal width.
+        Returns with long pulse elongation, for example, indicate that the laser reflection
+        is potentially smeared or refracted, such that the return pulse is elongated in time.
+        (Source: https://patrick-llgc.github.io/Learning-Deep-Learning/paper_notes/waymo_dataset.html)
         """
         record = self.get_record_at(frame_id=frame_id)
         # Range image to point cloud processing
@@ -240,12 +245,8 @@ class WaymoOpenDatasetLidarSensorFrameDecoder(LidarSensorFrameDecoder[datetime],
         )
 
         # Point Cloud Conversion and Viz
-        points = convert_range_image_to_point_cloud(
-            record, range_images, range_image_top_pose, keep_polar_features=True
-        )
-        points_ri2 = convert_range_image_to_point_cloud(
-            record, range_images, range_image_top_pose, ri_index=1, keep_polar_features=True
-        )
+        points = convert_range_image_to_point_cloud(record, range_images, range_image_top_pose)
+        points_ri2 = convert_range_image_to_point_cloud(record, range_images, range_image_top_pose, ri_index=1)
         # 3d points in vehicle frame.
         points_all = np.concatenate(points, axis=0)
         points_all_ri2 = np.concatenate(points_ri2, axis=0)

--- a/paralleldomain/decoding/waymo_open_dataset/sensor_frame_decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/sensor_frame_decoder.py
@@ -203,8 +203,10 @@ class WaymoOpenDatasetLidarSensorFrameDecoder(LidarSensorFrameDecoder[datetime],
         settings: DecoderSettings,
         use_precalculated_maps: bool,
         split_name: str,
+        include_second_returns: bool,
     ):
         self._dataset_path = dataset_path
+        self.include_second_returns = include_second_returns
         LidarSensorFrameDecoder.__init__(self=self, dataset_name=dataset_name, scene_name=scene_name, settings=settings)
         WaymoOpenDatasetSensorFrameDecoder.__init__(
             self=self,

--- a/paralleldomain/decoding/waymo_open_dataset/sensor_frame_decoder.py
+++ b/paralleldomain/decoding/waymo_open_dataset/sensor_frame_decoder.py
@@ -80,6 +80,7 @@ class WaymoOpenDatasetCameraSensorFrameDecoder(CameraSensorFrameDecoder[datetime
                 scene_name=self.scene_name,
                 sensor_name=sensor_name,
                 frame_id=frame_id,
+                split_name=self.split_name,
             )
             if has_segmentation:
                 return {


### PR DESCRIPTION
Expands Waymo Open Dataset decoder to support lidar and 3D bounding boxes.
Note: also updates the pre-commit version to avoid a isort<>Poetry versioning problem (see [here for details](https://levelup.gitconnected.com/fix-runtimeerror-poetry-isort-5db7c67b60ff))

Notes:

- Currently does not support the use of a single LiDAR scanner (use_all_lidar should always be set to its default True value). This can be added, but all 5 scanners use the coordinate frame of the TOP scanner, so they're pretty coupled.

- caching has not been added for point clouds yet.  Since every frame has point cloud data and bounding box annotations, there is no need for `frame_has_bbox`.