### PR TITLE
update isort version in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
       - id: mixed-line-ending
   - repo: https://github.com/pycqa/isort
-    rev: 5.8.0
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort


### PR DESCRIPTION
For new setups, there is a chained dependency issue in pre-commit:
* pre-commit depends on isort, which has a dependency on Poetry 
* That Poetry dependency is not pinned in isort, and a recent Poetry update broke isort
* Newer versions of isort (>=5.12.0) address the issue. This PR updates the isort version to avoid this bug.